### PR TITLE
feat: enhance tag auto-completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 .vscode-test
 *.log
 show-changelog.js
+/.idea

--- a/package.json
+++ b/package.json
@@ -239,7 +239,11 @@
         },
         "hledger.cache.watchPatterns": {
           "type": "array",
-          "default": ["**/*.journal", "**/*.hledger", "**/*.ledger"],
+          "default": [
+            "**/*.journal",
+            "**/*.hledger",
+            "**/*.ledger"
+          ],
           "items": {
             "type": "string"
           },
@@ -247,7 +251,10 @@
         },
         "hledger.cache.excludePatterns": {
           "type": "array",
-          "default": ["**/node_modules/**", "**/.git/**"],
+          "default": [
+            "**/node_modules/**",
+            "**/.git/**"
+          ],
           "items": {
             "type": "string"
           },

--- a/src/extension/__tests__/TagCompletionProvider.test.ts
+++ b/src/extension/__tests__/TagCompletionProvider.test.ts
@@ -79,7 +79,7 @@ describe('TagCompletionProvider', () => {
                 { tag: 'vendor', count: 2 },
                 { tag: 'Status', count: 2 }
             ]),
-            getTagValuesByUsage: jest.fn().mockImplementation((tagName: string) => {
+            getTagValuesByLastUsed: jest.fn().mockImplementation((tagName: string) => {
                 if (tagName === 'Event') {
                     return [
                         { value: '2025-02-freiburg', count: 2 },

--- a/src/extension/completion/providers/TagCompletionProvider.ts
+++ b/src/extension/completion/providers/TagCompletionProvider.ts
@@ -10,21 +10,31 @@ interface TagInfo {
     usageCount: number;
 }
 
+interface TagValueInfo {
+    value: string;
+    detail: string;
+    usageCount: number;
+}
+
 /**
- * Provides completion for tags in comment lines (after semicolon)
+ * Provides completion for tags and their values in comment lines (after semicolon)
+ * Supports both tag name completion and tag value completion based on context
  */
 export class TagCompletionProvider extends BaseCompletionProvider {
-    // Temporary storage for tag info during completion
+    // Temporary storage for completion info during completion
     private tagInfoMap?: Map<string, TagInfo>;
+    private tagValueInfoMap?: Map<string, TagValueInfo>;
+    
     protected shouldProvideCompletions(
         document: vscode.TextDocument,
         position: vscode.Position
     ): boolean {
         const linePrefix = document.lineAt(position).text.substring(0, position.character);
         
-        // Trigger in comments (after semicolon) when typing tag: or #
-        return linePrefix.match(/;\s*.*([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)?:?$/) !== null || 
-               linePrefix.match(/;\s*.*#([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)?$/) !== null;
+        // Trigger in comments (after semicolon) in these cases:
+        // 1. When typing tag name: ; Event or ; Subscription
+        // 2. When typing tag value after colon: ; Event: or ; Subscription:
+        return linePrefix.match(/;\s*.*([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)?:?.*$/) !== null;
     }
     
     protected getCompletionData(
@@ -33,40 +43,97 @@ export class TagCompletionProvider extends BaseCompletionProvider {
     ): CompletionData | null {
         const linePrefix = document.lineAt(position).text.substring(0, position.character);
         const config = getConfig(document);
-        const tagsByUsage = config.getTagsByUsage();
         
-        if (tagsByUsage.length === 0) {
-            return null;
+        // Check if we're completing a tag value (after colon, with optional spaces, anywhere in comment)
+        // Find the comment section first, then look for the last tag
+        const commentMatch = linePrefix.match(/;\s*(.*)$/);
+        if (commentMatch) {
+            const commentText = commentMatch[1];
+            // Find all tag patterns in the comment
+            const tagMatches = [...commentText.matchAll(/([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)\s*:\s*/g)];
+            
+            if (tagMatches.length > 0) {
+                // Get the last tag match
+                const lastTagMatch = tagMatches[tagMatches.length - 1];
+                const tagName = lastTagMatch[1];
+                const tagEndIndex = lastTagMatch.index! + lastTagMatch[0].length;
+                const typedValue = commentText.substring(tagEndIndex);
+                const tagValuesByUsage = config.getTagValuesByUsage(tagName);
+                
+                if (tagValuesByUsage.length === 0) {
+                    return null;
+                }
+                
+                // Build tag value info list with metadata
+                const tagValueInfoList: TagValueInfo[] = tagValuesByUsage.map(({value, count}) => ({
+                    value,
+                    detail: count > 0 ? `${tagName} value (used ${count} times)` : `${tagName} value`,
+                    usageCount: count
+                }));
+                
+                // Create usage counts map for fuzzy matcher
+                const usageCounts = new Map<string, number>();
+                tagValueInfoList.forEach(info => {
+                    usageCounts.set(info.value, info.usageCount);
+                });
+                
+                // Store tag value info in a map for later lookup
+                this.tagValueInfoMap = new Map<string, TagValueInfo>();
+                tagValueInfoList.forEach(info => {
+                    this.tagValueInfoMap!.set(info.value, info);
+                });
+                
+                return {
+                    items: tagValueInfoList.map(info => info.value),
+                    query: typedValue,
+                    usageCounts
+                };
+            }
         }
         
-        // Look for tag:value format or #tag format
-        const tagMatch = linePrefix.match(/([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)(:?)$/);
-        const typedText = tagMatch ? tagMatch[1] : '';
+        // If we get here, we're completing a tag name (not a value)
+        const commentMatch2 = linePrefix.match(/;\s*(.*)$/);
+        if (commentMatch2) {
+            // Completing tag name
+            const tagsByUsage = config.getTagsByUsage();
+            
+            if (tagsByUsage.length === 0) {
+                return null;
+            }
+            
+            // Look for tag name being typed anywhere in the comment
+            // This handles cases like "; comment comment Event" or "; Event" 
+            const tagMatch = linePrefix.match(/;\s*.*?([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)$/);
+            const typedText = tagMatch ? tagMatch[1] : '';
+            
+            // Build tag info list with metadata
+            const tagInfoList: TagInfo[] = tagsByUsage.map(({tag, count}) => ({
+                tag,
+                detail: count > 0 ? `Tag/Category (used ${count} times)` : 'Tag/Category',
+                usageCount: count
+            }));
+            
+            // Create usage counts map for fuzzy matcher
+            const usageCounts = new Map<string, number>();
+            tagInfoList.forEach(info => {
+                usageCounts.set(unbranded(info.tag), info.usageCount);
+            });
+            
+            // Store tag info in a map for later lookup
+            this.tagInfoMap = new Map<string, TagInfo>();
+            tagInfoList.forEach(info => {
+                this.tagInfoMap!.set(unbranded(info.tag), info);
+            });
+            
+            return {
+                items: tagInfoList.map(info => unbranded(info.tag)),
+                query: typedText,
+                usageCounts
+            };
+        }
         
-        // Build tag info list with metadata
-        const tagInfoList: TagInfo[] = tagsByUsage.map(({tag, count}) => ({
-            tag,
-            detail: count > 0 ? `Tag/Category (used ${count} times)` : 'Tag/Category',
-            usageCount: count
-        }));
-        
-        // Create usage counts map for fuzzy matcher
-        const usageCounts = new Map<string, number>();
-        tagInfoList.forEach(info => {
-            usageCounts.set(unbranded(info.tag), info.usageCount);
-        });
-        
-        // Store tag info in a map for later lookup
-        this.tagInfoMap = new Map<string, TagInfo>();
-        tagInfoList.forEach(info => {
-            this.tagInfoMap!.set(unbranded(info.tag), info);
-        });
-        
-        return {
-            items: tagInfoList.map(info => unbranded(info.tag)),
-            query: typedText,
-            usageCounts
-        };
+        // No completion data available
+        return null;
     }
     
     protected getCompletionItemOptions(data: CompletionData): CompletionItemOptions {
@@ -92,15 +159,37 @@ export class TagCompletionProvider extends BaseCompletionProvider {
             return items;
         }
         
-        // Customize each item with tag-specific metadata
+        const linePrefix = document.lineAt(position).text.substring(0, position.character);
+        // Check if we're completing a tag value by looking for the last tag pattern
+        const commentMatch = linePrefix.match(/;\s*(.*)$/);
+        let isCompletingValue = false;
+        if (commentMatch) {
+            const commentText = commentMatch[1];
+            const tagMatches = [...commentText.matchAll(/([a-zA-Z\u0400-\u04FF][a-zA-Z\u0400-\u04FF0-9_]*)\s*:\s*/g)];
+            isCompletingValue = tagMatches.length > 0;
+        }
+        
+        // Customize each item based on what we're completing
         return items.map(item => {
-            const tagInfo = this.tagInfoMap?.get(item.label.toString());
-            if (tagInfo) {
-                item.detail = tagInfo.detail;
+            if (isCompletingValue) {
+                // Completing tag value
+                const tagValueInfo = this.tagValueInfoMap?.get(item.label.toString());
+                if (tagValueInfo) {
+                    item.detail = tagValueInfo.detail;
+                    item.kind = vscode.CompletionItemKind.Value;
+                }
+                // Insert text is just the value
+                item.insertText = item.label.toString();
+            } else {
+                // Completing tag name
+                const tagInfo = this.tagInfoMap?.get(item.label.toString());
+                if (tagInfo) {
+                    item.detail = tagInfo.detail;
+                    item.kind = vscode.CompletionItemKind.Keyword;
+                }
+                // Set insert text for tag:value format (with colon and space for better UX)
+                item.insertText = item.label.toString() + ': ';
             }
-            
-            // Set insert text for tag:value format
-            item.insertText = item.label.toString() + ':';
             
             return item;
         });
@@ -111,5 +200,6 @@ export class TagCompletionProvider extends BaseCompletionProvider {
      */
     public invalidateCache(): void {
         this.tagInfoMap = undefined;
+        this.tagValueInfoMap = undefined;
     }
 }

--- a/src/extension/completion/providers/TagCompletionProvider.ts
+++ b/src/extension/completion/providers/TagCompletionProvider.ts
@@ -58,7 +58,7 @@ export class TagCompletionProvider extends BaseCompletionProvider {
                 const tagName = lastTagMatch[1];
                 const tagEndIndex = lastTagMatch.index! + lastTagMatch[0].length;
                 const typedValue = commentText.substring(tagEndIndex);
-                const tagValuesByUsage = config.getTagValuesByUsage(tagName);
+                const tagValuesByUsage = config.getTagValuesByLastUsed(tagName);
                 
                 if (tagValuesByUsage.length === 0) {
                     return null;

--- a/src/extension/core/ConfigManager.ts
+++ b/src/extension/core/ConfigManager.ts
@@ -171,6 +171,16 @@ export class ConfigManager implements IConfigManager {
         })).sort((a: {commodity: CommodityName, count: number}, b: {commodity: CommodityName, count: number}) => b.count - a.count);
     }
     
+    // === Tag Value Methods ===
+    
+    getTagValues(tagName: string): string[] {
+        return this.dataStore.getTagValues(tagName);
+    }
+    
+    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}> {
+        return this.usageTracker.getTagValuesByUsage(tagName);
+    }
+    
     // === Legacy Properties (for backward compatibility) ===
     
     /** @deprecated Use getAccounts() instead */
@@ -316,5 +326,17 @@ export class ConfigManager implements IConfigManager {
                 this.usageTracker.incrementCommodityUsage(createCommodityName(commodity));
             }
         });
+        
+        // Update tag values if present
+        if (parsedData.tagValueUsage) {
+            parsedData.tagValueUsage.forEach((valueMap: Map<string, number>, tagName: string) => {
+                valueMap.forEach((count: number, value: string) => {
+                    this.dataStore.addTagValue(tagName, value);
+                    for (let i = 0; i < count; i++) {
+                        this.usageTracker.incrementTagValueUsage(tagName, value);
+                    }
+                });
+            });
+        }
     }
 }

--- a/src/extension/core/ConfigManager.ts
+++ b/src/extension/core/ConfigManager.ts
@@ -177,8 +177,8 @@ export class ConfigManager implements IConfigManager {
         return this.dataStore.getTagValues(tagName);
     }
     
-    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}> {
-        return this.usageTracker.getTagValuesByUsage(tagName);
+    getTagValuesByLastUsed(tagName: string): Array<{value: string, count: number}> {
+        return this.usageTracker.getTagValuesByLastUsed(tagName);
     }
     
     // === Legacy Properties (for backward compatibility) ===

--- a/src/extension/core/DataStore.ts
+++ b/src/extension/core/DataStore.ts
@@ -19,6 +19,7 @@ export class DataStore implements IDataStore {
     private _usedAccounts: Set<AccountName> = new Set();
     private _payees: Set<PayeeName> = new Set();
     private _tags: Set<TagEntry> = new Set();
+    private _tagValues: Map<string, Set<string>> = new Map();
     private _commodities: Set<CommodityName> = new Set();
     private _aliases: Map<AccountAlias, AccountName> = new Map();
     private _defaultCommodity: CommodityName | null = null;
@@ -164,6 +165,26 @@ export class DataStore implements IDataStore {
         return this._lastDate;
     }
     
+    // === Tag Value Methods ===
+    
+    /**
+     * Get tag values for a specific tag name
+     */
+    getTagValues(tagName: string): string[] {
+        const values = this._tagValues.get(tagName);
+        return values ? Array.from(values) : [];
+    }
+    
+    /**
+     * Add a tag value for a specific tag name
+     */
+    addTagValue(tagName: string, value: string): void {
+        if (!this._tagValues.has(tagName)) {
+            this._tagValues.set(tagName, new Set());
+        }
+        this._tagValues.get(tagName)!.add(value);
+    }
+    
     // === Utility ===
     
     /**
@@ -175,6 +196,7 @@ export class DataStore implements IDataStore {
         this._usedAccounts.clear();
         this._payees.clear();
         this._tags.clear();
+        this._tagValues.clear();
         this._commodities.clear();
         this._aliases.clear();
         this._defaultCommodity = null;
@@ -193,6 +215,14 @@ export class DataStore implements IDataStore {
         // Merge other data
         other.getPayees().forEach(payee => this.addPayee(payee));
         other.getTags().forEach(tag => this.addTag(tag));
+        
+        // Merge tag values
+        other.getTags().forEach(tag => {
+            const tagName = unbranded(tag);
+            const values = other.getTagValues(tagName);
+            values.forEach(value => this.addTagValue(tagName, value));
+        });
+        
         other.getCommodities().forEach(commodity => this.addCommodity(commodity));
         
         // Merge aliases

--- a/src/extension/core/UsageTracker.ts
+++ b/src/extension/core/UsageTracker.ts
@@ -158,7 +158,7 @@ export class UsageTracker implements IUsageTracker {
     /**
      * Get tag values sorted by last usage time (most recent first)
      */
-    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}> {
+    getTagValuesByLastUsed(tagName: string): Array<{value: string, count: number}> {
         const values = this._tagValueUsage.get(tagName);
         const lastUsed = this._tagValueLastUsed.get(tagName);
         if (!values) {
@@ -284,7 +284,7 @@ export class UsageTracker implements IUsageTracker {
         // Merge tag value usage
         other.getTagsByUsage().forEach(({ tag, count: _ }) => {
             const tagName = unbranded(tag);
-            const tagValues = other.getTagValuesByUsage(tagName);
+            const tagValues = other.getTagValuesByLastUsed(tagName);
             tagValues.forEach(({ value, count }) => {
                 if (!this._tagValueUsage.has(tagName)) {
                     this._tagValueUsage.set(tagName, new Map());

--- a/src/extension/core/interfaces.ts
+++ b/src/extension/core/interfaces.ts
@@ -297,9 +297,9 @@ export interface IUsageTracker extends IUsageTrackerInternal {
     getTagValues(tagName: string): string[];
     
     /**
-     * Get tag values sorted by usage frequency for a specific tag name
+     * Get tag values sorted by last usage time (most recent first) for a specific tag name
      */
-    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}>;
+    getTagValuesByLastUsed(tagName: string): Array<{value: string, count: number}>;
     
     /**
      * Add a tag value for a specific tag name
@@ -522,9 +522,9 @@ export interface IConfigManager extends IComponentContainer {
     getTagValues(tagName: string): string[];
     
     /**
-     * Get tag values sorted by usage frequency for a specific tag name
+     * Get tag values sorted by last usage time (most recent first) for a specific tag name
      */
-    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}>;
+    getTagValuesByLastUsed(tagName: string): Array<{value: string, count: number}>;
     
     // === Legacy Properties (for backward compatibility) ===
     

--- a/src/extension/core/interfaces.ts
+++ b/src/extension/core/interfaces.ts
@@ -204,6 +204,18 @@ export interface IDataStore extends IDataStoreInternal {
      */
     getLastDate(): DateString | null;
     
+    // === Tag Value Methods ===
+    
+    /**
+     * Get tag values for a specific tag name
+     */
+    getTagValues(tagName: string): string[];
+    
+    /**
+     * Add a tag value for a specific tag name
+     */
+    addTagValue(tagName: string, value: string): void;
+    
     // === Utility ===
     
     /**
@@ -276,6 +288,28 @@ export interface IUsageTracker extends IUsageTrackerInternal {
      * Get commodities sorted by usage frequency (most used first)
      */
     getCommoditiesByUsage(): Array<{commodity: CommodityName, count: number}>;
+    
+    // === Tag Value Methods ===
+    
+    /**
+     * Get tag values for a specific tag name
+     */
+    getTagValues(tagName: string): string[];
+    
+    /**
+     * Get tag values sorted by usage frequency for a specific tag name
+     */
+    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}>;
+    
+    /**
+     * Add a tag value for a specific tag name
+     */
+    addTagValue(tagName: string, value: string): void;
+    
+    /**
+     * Increment usage count for a specific tag value
+     */
+    incrementTagValueUsage(tagName: string, value: string): void;
     
     // === Individual Usage Retrieval ===
     
@@ -372,6 +406,9 @@ export interface ParsedHLedgerData {
     
     /** Usage statistics for tags */
     tagUsage: Map<TagEntry, number>;
+    
+    /** Tag values organized by tag name with usage counts */
+    tagValueUsage?: Map<string, Map<string, number>>;
     
     /** Usage statistics for commodities */
     commodityUsage: Map<CommodityName, number>;
@@ -476,6 +513,18 @@ export interface IConfigManager extends IComponentContainer {
     getPayeesByUsage(): Array<{payee: PayeeName, count: number}>;
     getTagsByUsage(): Array<{tag: TagEntry, count: number}>;
     getCommoditiesByUsage(): Array<{commodity: CommodityName, count: number}>;
+    
+    // === Tag Value Methods ===
+    
+    /**
+     * Get tag values for a specific tag name
+     */
+    getTagValues(tagName: string): string[];
+    
+    /**
+     * Get tag values sorted by usage frequency for a specific tag name
+     */
+    getTagValuesByUsage(tagName: string): Array<{value: string, count: number}>;
     
     // === Legacy Properties (for backward compatibility) ===
     

--- a/testdata/test-completion.journal
+++ b/testdata/test-completion.journal
@@ -1,0 +1,33 @@
+2025-01-29 * DB Bahn
+    ; Event: 2025-02-freiburg
+    ; Muenster - Freiburg
+    Expenses:Travels:Transport                          101.80 EUR
+    Assets:Mastercard
+
+2025-08-06 * Backblaze
+    ; Subscription: monthly
+    Expenses:Subscriptions:Backblaze                      2.61 EUR
+    Assets:Mastercard
+
+2025-01-15 * Another Event
+    ; Event: 2025-03-berlin
+    ; Project: website
+    Expenses:Events                                      50.00 EUR
+    Assets:Checking
+
+2025-01-20 * Another Subscription
+    ; Subscription: yearly
+    ; Category: software
+    Expenses:Software                                    99.00 EUR
+    Assets:Checking
+
+2025-01-25 * Final Event
+    ; Event: 2025-02-freiburg
+    ; Status: confirmed
+    Expenses:Events                                      25.00 EUR
+    Assets:Cash
+
+2025-01-30 * Test multiple tags
+    ; Status: pending Category: hardware Event: 
+    Expenses:Equipment                                   150.00 EUR
+    Assets:Cash


### PR DESCRIPTION
## Summary
- support auto-completion for the tags like `Event: vacation` or `Subscription: yearly`

Example:

```
2025-08-08 * Office
    ; Purpose: homeoffice
    Expenses:Other                                        2.13 EUR
    ; Paper
    Assets:Mastercard
```

To show the auto-completion list press "Ctrl+Space" (macOS).