### PR TITLE
fix: update completion item provider triggers to exclude space for account and currency completions

### DIFF
--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -32,9 +32,8 @@ export function activate(context: vscode.ExtensionContext): void {
             vscode.languages.registerCompletionItemProvider(
                 'hledger',
                 strictProvider,
-                // Triggers for different completion contexts:
+                // Triggers for different completion contexts (space intentionally excluded):
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',  // Date completion at line start
-                ' ',  // After date for accounts, after amount for currencies
                 ':',  // Account hierarchy
                 '@',  // Commodities
                 ';'   // Comments (future use)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exclude space from hledger completion provider triggers, keeping numeric, ':' '@' and ';' triggers intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3f6493c8bfa430af7bd225baa9011198275996d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->