### PR TITLE
fix: filter out incomplete typed text from account completions

### DIFF
--- a/src/extension/HLedgerConfig.ts
+++ b/src/extension/HLedgerConfig.ts
@@ -156,6 +156,12 @@ export class HLedgerConfig {
       currentLine,
     );
     const currentData = this.parser.parseContent(currentContent, filePath);
+
+    // Clone workspace data before merging to prevent cache pollution.
+    // This ensures incomplete data from current line doesn't persist in cache.
+    if (currentLine !== undefined && this.data) {
+      this.data = this.cloneData(this.data);
+    }
     this.mergeCurrentData(currentData);
   }
 
@@ -205,6 +211,36 @@ export class HLedgerConfig {
       payeeUsage: Map<PayeeName, UsageCount>;
       tagUsage: Map<TagName, UsageCount>;
       commodityUsage: Map<CommodityCode, UsageCount>;
+    };
+  }
+
+  /**
+   * Creates a deep clone of ParsedHLedgerData to prevent cache mutation.
+   * Used when currentLine is provided to ensure workspace cache stays clean.
+   */
+  private cloneData(data: ParsedHLedgerData): ParsedHLedgerData {
+    return {
+      accounts: new Set(data.accounts),
+      usedAccounts: new Set(data.usedAccounts),
+      definedAccounts: new Set(data.definedAccounts),
+      payees: new Set(data.payees),
+      tags: new Set(data.tags),
+      commodities: new Set(data.commodities),
+      accountUsage: new Map(data.accountUsage),
+      payeeUsage: new Map(data.payeeUsage),
+      tagUsage: new Map(data.tagUsage),
+      commodityUsage: new Map(data.commodityUsage),
+      aliases: new Map(data.aliases),
+      defaultCommodity: data.defaultCommodity,
+      lastDate: data.lastDate,
+      payeeAccounts: new Map(
+        [...data.payeeAccounts].map(([k, v]) => [k, new Set(v)]),
+      ),
+      payeeAccountPairUsage: new Map(data.payeeAccountPairUsage),
+      tagValues: new Map([...data.tagValues].map(([k, v]) => [k, new Set(v)])),
+      tagValueUsage: new Map(data.tagValueUsage),
+      commodityFormats: new Map(data.commodityFormats),
+      decimalMark: data.decimalMark,
     };
   }
 

--- a/src/extension/__tests__/HLedgerConfig.test.ts
+++ b/src/extension/__tests__/HLedgerConfig.test.ts
@@ -1,5 +1,7 @@
 import { HLedgerConfig } from '../main';
-import { createAccountName } from '../types';
+import { HLedgerParser, ParsedHLedgerData } from '../HLedgerParser';
+import { SimpleProjectCache } from '../SimpleProjectCache';
+import { createAccountName, createUsageCount } from '../types';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -202,6 +204,131 @@ account Assets:Bank
             
             // Verify that no data was parsed due to error
             expect(config.getAccounts()).toEqual([]);
+        });
+    });
+
+    describe('getConfigForDocument - cache pollution prevention', () => {
+        it('should clone data before merging when currentLine is provided', () => {
+            // This test verifies that when getConfigForDocument is called with currentLine,
+            // the workspace data is cloned before mergeCurrentData mutates it.
+            //
+            // The bug: this.data and this.cache share the same object reference.
+            // When mergeCurrentData() mutates this.data, it also pollutes the cache.
+            //
+            // Testing strategy:
+            // 1. Set up internal state to simulate cached workspace data
+            // 2. Call getConfigForDocument with a document containing new data
+            // 3. Verify the original workspace data Set was NOT mutated
+
+            // Create workspace data with mutable Sets that we can verify
+            const originalAccountsSet = new Set(['Assets:Bank', 'Expenses:Food']);
+            const originalUsedAccountsSet = new Set<string>();
+
+            const workspaceData: ParsedHLedgerData = {
+                accounts: originalAccountsSet,
+                definedAccounts: new Set(['Assets:Bank', 'Expenses:Food']),
+                usedAccounts: originalUsedAccountsSet,
+                payees: new Set(),
+                tags: new Set(),
+                commodities: new Set(),
+                aliases: new Map(),
+                accountUsage: new Map(),
+                payeeUsage: new Map(),
+                tagUsage: new Map(),
+                commodityUsage: new Map(),
+                tagValues: new Map(),
+                tagValueUsage: new Map(),
+                payeeAccounts: new Map(),
+                payeeAccountPairUsage: new Map(),
+                commodityFormats: new Map(),
+                decimalMark: null,
+                defaultCommodity: null,
+                lastDate: null
+            };
+
+            // Inject the shared cache that holds workspace data
+            const sharedCache = new SimpleProjectCache();
+            sharedCache.set('/test/project', workspaceData);
+
+            // Create config with the shared cache
+            const parser = new HLedgerParser();
+            const configWithSharedCache = new HLedgerConfig(parser, sharedCache);
+
+            // Set internal state to simulate a prior workspace parse
+            const internalConfig = configWithSharedCache as unknown as {
+                data: ParsedHLedgerData;
+                lastWorkspacePath: string;
+            };
+            internalConfig.data = workspaceData;
+            internalConfig.lastWorkspacePath = '/test/project';
+
+            // Verify initial state
+            expect(originalAccountsSet.size).toBe(2);
+            expect(originalAccountsSet.has('Assets:NewAccount')).toBe(false);
+            expect(originalUsedAccountsSet.size).toBe(0);
+
+            // Create a document with new account data
+            // Note: The posting account needs proper indentation (spaces/tab) and amount separation
+            const documentContent = `2025-01-15 Test transaction
+    Assets:NewAccount    100
+    Expenses:Food       -100
+`;
+            const fileUri = {
+                scheme: 'file',
+                authority: '',
+                path: '/test/project/test.journal',
+                query: '',
+                fragment: '',
+                fsPath: '/test/project/test.journal',
+                with: jest.fn(),
+                toString: () => 'file:///test/project/test.journal',
+                toJSON: () => ({ $mid: 1, fsPath: '/test/project/test.journal', path: '/test/project/test.journal', scheme: 'file' })
+            };
+
+            const document = new MockTextDocument(documentContent.split('\n'), {
+                uri: fileUri as vscode.Uri,
+                fileName: '/test/project/test.journal',
+                languageId: 'hledger'
+            });
+
+            const workspaceFolder = {
+                uri: {
+                    scheme: 'file',
+                    fsPath: '/test/project',
+                    path: '/test/project',
+                    authority: '',
+                    query: '',
+                    fragment: '',
+                    with: jest.fn(),
+                    toString: () => 'file:///test/project',
+                    toJSON: () => ({})
+                },
+                name: 'project',
+                index: 0
+            };
+            (vscode.workspace.getWorkspaceFolder as jest.Mock).mockReturnValue(workspaceFolder);
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
+            (fs.readdirSync as jest.Mock).mockReturnValue([]);
+
+            // Call with currentLine=2 (the Expenses:Food posting line, so Assets:NewAccount is included)
+            // This triggers mergeCurrentData which mutates this.data
+            configWithSharedCache.getConfigForDocument(document, 2);
+
+            // After merge, the config should see the new account from the document
+            const accountsAfterMerge = configWithSharedCache.getAccounts();
+            expect(accountsAfterMerge).toContain('Assets:NewAccount');
+            expect(accountsAfterMerge).toContain('Expenses:Food');
+
+            // CRITICAL ASSERTION: The original workspace data Set should NOT be mutated
+            // This is the cache pollution bug we're testing for.
+            //
+            // With the bug: originalAccountsSet.has('Assets:NewAccount') === true (POLLUTION!)
+            // With the fix: originalAccountsSet.has('Assets:NewAccount') === false (CLEAN!)
+            expect(originalAccountsSet.has('Assets:NewAccount')).toBe(false);
+            expect(originalAccountsSet.size).toBe(2);
+
+            // Also verify usedAccounts wasn't polluted
+            expect(originalUsedAccountsSet.has('Assets:NewAccount')).toBe(false);
         });
     });
 


### PR DESCRIPTION
Add safety filter in AccountCompleter to exclude exact query matches with low usage count (≤2). This prevents incomplete text like "прод" from appearing in completions after canceling and re-triggering.

Also includes:
- cloneData() in HLedgerConfig to prevent cache pollution from current document merges
- Tests for cache pollution prevention

🤖 Generated with [Claude Code](https://claude.com/claude-code)