### PR TITLE
feat: add config options for align amount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ Commands (`hledger.cli.balance`, `hledger.cli.incomestatement`, `hledger.cli.sta
 
 2. **README.md** - Update if:
    - Adding major new features (add to Features section)
+   - Adding/modifying configuration options (update Essential Settings section)
    - Changing installation instructions
    - Modifying quick start workflow
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,10 @@ Import bank statements and transaction data from CSV/TSV files.
   "hledger.semanticHighlighting.enabled": false,  // Enable for more precision
 
   // Validation diagnostics
-  "hledger.diagnostics.enabled": true  // Disable to turn off validation warnings
+  "hledger.diagnostics.enabled": true,  // Disable to turn off validation warnings
+
+  // Formatting
+  "hledger.formatting.amountAlignmentColumn": 40  // Column for amount alignment (20-120)
 }
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -261,9 +261,12 @@ Press **Tab** after an account name to position cursor at the optimal amount col
 ```
 
 The amount column is calculated based on:
+- Configured minimum column (`hledger.formatting.amountAlignmentColumn`, default 40)
 - Maximum account name length in the transaction block
 - Multi-currency alignment requirements
 - Balance assertion space requirements
+
+The configured value is the **minimum** position. If accounts are longer than the configured column allows, alignment shifts further right to maintain the required 2-space gap.
 
 ### Completion Triggers
 
@@ -634,6 +637,14 @@ Map CSV category values to hledger accounts:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `hledger.diagnostics.enabled` | boolean | `true` | Enable validation diagnostics |
+
+### Formatting Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `hledger.formatting.amountAlignmentColumn` | number | `40` | Minimum column for amount alignment (20-120) |
+
+**Note:** The `amountAlignmentColumn` setting specifies the minimum column position. Amounts are aligned at least at this column, but may shift further right when account names are long enough to require additional space.
 
 ### Syntax Highlighting Settings
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,13 @@
           "default": true,
           "description": "Enable diagnostics validation for hledger files (account checks, tag format, amount format)"
         },
+        "hledger.formatting.amountAlignmentColumn": {
+          "type": "number",
+          "default": 40,
+          "minimum": 20,
+          "maximum": 120,
+          "description": "Minimum column position for amount alignment. Amounts align at least at this column, but may shift further right for long account names."
+        },
         "hledger.autoCompletion.transactionTemplates.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/extension/HLedgerConfig.ts
+++ b/src/extension/HLedgerConfig.ts
@@ -426,7 +426,25 @@ export class HLedgerConfig {
   }
 
   // Formatting profile methods
+
+  /**
+   * Gets the user-configured alignment column from VS Code settings.
+   * Returns 0 if not configured, allowing caller to use default behavior.
+   */
+  private getConfiguredAlignmentColumn(): number {
+    const config = vscode.workspace.getConfiguration("hledger");
+    return config.get<number>("formatting.amountAlignmentColumn", 0);
+  }
+
   getAmountAlignmentColumn(): CharacterPosition {
+    const configuredColumn = this.getConfiguredAlignmentColumn();
+    const maxAccountLength = this.data?.formattingProfile?.maxAccountNameLength ?? 0;
+
+    // Recalculate with configured column to ensure user preference is applied
+    if (configuredColumn > 0) {
+      return calculateAlignmentColumn(maxAccountLength, configuredColumn);
+    }
+
     return (
       this.data?.formattingProfile?.amountAlignmentColumn ??
       createCharacterPosition(DEFAULT_AMOUNT_ALIGNMENT_COLUMN)

--- a/src/extension/__tests__/HLedgerTabCommand.test.ts
+++ b/src/extension/__tests__/HLedgerTabCommand.test.ts
@@ -20,7 +20,13 @@ jest.mock('vscode', () => ({
     },
     workspace: {
         getConfiguration: jest.fn().mockReturnValue({
-            get: jest.fn().mockReturnValue(true)
+            get: jest.fn().mockImplementation((key: string, defaultValue?: unknown) => {
+                // Return appropriate defaults based on configuration key
+                if (key === 'formatting.amountAlignmentColumn') {
+                    return defaultValue ?? 0;
+                }
+                return defaultValue ?? true;
+            })
         })
     },
     Position: jest.fn().mockImplementation((line, character) => ({ line, character })),

--- a/src/extension/utils/__tests__/formattingUtils.test.ts
+++ b/src/extension/utils/__tests__/formattingUtils.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for formattingUtils - Amount alignment calculation utilities.
+ */
+import { calculateAlignmentColumn, DEFAULT_AMOUNT_ALIGNMENT_COLUMN, POSTING_INDENT, MIN_AMOUNT_SPACING, mergeFormattingProfiles } from "../formattingUtils";
+import { createCharacterPosition, FormattingProfile } from "../../types";
+
+describe("calculateAlignmentColumn", () => {
+  describe("with default alignment column (40)", () => {
+    it("returns default when account name is short", () => {
+      const result = calculateAlignmentColumn(20);
+      expect(result).toBe(DEFAULT_AMOUNT_ALIGNMENT_COLUMN);
+    });
+
+    it("returns default when maxAccountNameLength is 0", () => {
+      const result = calculateAlignmentColumn(0);
+      expect(result).toBe(DEFAULT_AMOUNT_ALIGNMENT_COLUMN);
+    });
+
+    it("returns calculated value when account is long enough", () => {
+      // POSTING_INDENT (4) + 44 + MIN_AMOUNT_SPACING (2) = 50
+      const result = calculateAlignmentColumn(44);
+      expect(result).toBe(50);
+    });
+
+    it("handles boundary case at default column", () => {
+      // POSTING_INDENT (4) + 34 + MIN_AMOUNT_SPACING (2) = 40 (equals default)
+      const result = calculateAlignmentColumn(34);
+      expect(result).toBe(DEFAULT_AMOUNT_ALIGNMENT_COLUMN);
+    });
+
+    it("handles negative input gracefully", () => {
+      const result = calculateAlignmentColumn(-10);
+      expect(result).toBe(DEFAULT_AMOUNT_ALIGNMENT_COLUMN);
+    });
+
+    it("caps extremely large account name lengths", () => {
+      // Should cap at MAX_ACCOUNT_NAME_LENGTH (1000) to prevent overflow
+      const result = calculateAlignmentColumn(1000000);
+      // 4 + 1000 + 2 = 1006
+      expect(result).toBe(POSTING_INDENT + 1000 + MIN_AMOUNT_SPACING);
+    });
+  });
+
+  describe("with custom configured alignment column", () => {
+    it("uses configured column as minimum when account is short", () => {
+      // With configured column of 50, short account should align at 50
+      const result = calculateAlignmentColumn(20, 50);
+      expect(result).toBe(50);
+    });
+
+    it("respects configured column of 60", () => {
+      const result = calculateAlignmentColumn(10, 60);
+      expect(result).toBe(60);
+    });
+
+    it("expands beyond configured column for long accounts", () => {
+      // POSTING_INDENT (4) + 60 + MIN_AMOUNT_SPACING (2) = 66
+      // Even with configured column of 50, long account pushes alignment to 66
+      const result = calculateAlignmentColumn(60, 50);
+      expect(result).toBe(66);
+    });
+
+    it("uses configured column of 20 (minimum allowed)", () => {
+      const result = calculateAlignmentColumn(5, 20);
+      expect(result).toBe(20);
+    });
+
+    it("uses configured column of 120 (maximum allowed)", () => {
+      const result = calculateAlignmentColumn(10, 120);
+      expect(result).toBe(120);
+    });
+
+    it("falls back to default when configured column is 0", () => {
+      // 0 means use default behavior
+      const result = calculateAlignmentColumn(10, 0);
+      expect(result).toBe(DEFAULT_AMOUNT_ALIGNMENT_COLUMN);
+    });
+
+    it("handles configured column less than minimum spacing requirement", () => {
+      // Even with very small configured column, minimum spacing must be maintained
+      // POSTING_INDENT (4) + 30 + MIN_AMOUNT_SPACING (2) = 36
+      // Configured 10 is less than 36, so 36 wins
+      const result = calculateAlignmentColumn(30, 10);
+      expect(result).toBe(36);
+    });
+  });
+});
+
+describe("mergeFormattingProfiles", () => {
+  it("keeps larger maxAccountNameLength", () => {
+    const target: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 20,
+      isDefaultAlignment: false,
+    };
+    const source: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 30,
+      isDefaultAlignment: false,
+    };
+
+    const result = mergeFormattingProfiles(target, source);
+    expect(result.maxAccountNameLength).toBe(30);
+  });
+
+  it("preserves target maxAccountNameLength when larger", () => {
+    const target: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(50),
+      maxAccountNameLength: 50,
+      isDefaultAlignment: false,
+    };
+    const source: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 30,
+      isDefaultAlignment: false,
+    };
+
+    const result = mergeFormattingProfiles(target, source);
+    expect(result.maxAccountNameLength).toBe(50);
+  });
+
+  it("recalculates amountAlignmentColumn based on merged maxAccountNameLength", () => {
+    const target: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 20,
+      isDefaultAlignment: true,
+    };
+    const source: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 50,
+      isDefaultAlignment: false,
+    };
+
+    const result = mergeFormattingProfiles(target, source);
+    // 4 + 50 + 2 = 56
+    expect(result.amountAlignmentColumn).toBe(56);
+    expect(result.isDefaultAlignment).toBe(false);
+  });
+
+  it("sets isDefaultAlignment true when both have zero maxAccountNameLength", () => {
+    const target: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 0,
+      isDefaultAlignment: true,
+    };
+    const source: FormattingProfile = {
+      amountAlignmentColumn: createCharacterPosition(40),
+      maxAccountNameLength: 0,
+      isDefaultAlignment: true,
+    };
+
+    const result = mergeFormattingProfiles(target, source);
+    expect(result.isDefaultAlignment).toBe(true);
+  });
+});
+
+describe("constants", () => {
+  it("DEFAULT_AMOUNT_ALIGNMENT_COLUMN is 40", () => {
+    expect(DEFAULT_AMOUNT_ALIGNMENT_COLUMN).toBe(40);
+  });
+
+  it("POSTING_INDENT is 4", () => {
+    expect(POSTING_INDENT).toBe(4);
+  });
+
+  it("MIN_AMOUNT_SPACING is 2", () => {
+    expect(MIN_AMOUNT_SPACING).toBe(2);
+  });
+});

--- a/src/extension/utils/formattingUtils.ts
+++ b/src/extension/utils/formattingUtils.ts
@@ -18,27 +18,38 @@ const MAX_ACCOUNT_NAME_LENGTH = 1000;
 /**
  * Calculates the amount alignment column based on maximum account name length.
  *
- * Formula: POSTING_INDENT + maxAccountNameLength + MIN_AMOUNT_SPACING
- * Minimum: DEFAULT_AMOUNT_ALIGNMENT_COLUMN (40)
+ * Formula: max(POSTING_INDENT + maxAccountNameLength + MIN_AMOUNT_SPACING, minimumColumn)
+ * The minimumColumn defaults to DEFAULT_AMOUNT_ALIGNMENT_COLUMN (40) if not provided.
  *
  * @param maxAccountNameLength - Length of the longest account name in workspace
+ * @param configuredColumn - Optional user-configured minimum alignment column.
+ *                           When provided and > 0, used instead of DEFAULT_AMOUNT_ALIGNMENT_COLUMN.
+ *                           This allows users to customize the minimum amount position.
  * @returns Column position where amounts should start
  *
  * @example
- * calculateAlignmentColumn(0)   // → 40 (default minimum)
- * calculateAlignmentColumn(30)  // → 40 (4 + 30 + 2 = 36, but min is 40)
- * calculateAlignmentColumn(44)  // → 50 (4 + 44 + 2 = 50)
+ * calculateAlignmentColumn(0)       // → 40 (default minimum)
+ * calculateAlignmentColumn(30)      // → 40 (4 + 30 + 2 = 36, but min is 40)
+ * calculateAlignmentColumn(44)      // → 50 (4 + 44 + 2 = 50)
+ * calculateAlignmentColumn(10, 50)  // → 50 (configured minimum takes precedence)
+ * calculateAlignmentColumn(60, 50)  // → 66 (4 + 60 + 2 = 66 > 50)
  */
 export function calculateAlignmentColumn(
   maxAccountNameLength: number,
+  configuredColumn?: number,
 ): CharacterPosition {
   // Ensure non-negative and cap at reasonable maximum
   const safeLength = Math.max(0, Math.min(maxAccountNameLength, MAX_ACCOUNT_NAME_LENGTH));
 
+  // Use configured column if provided and valid (> 0), otherwise use default
+  const minimumColumn = configuredColumn !== undefined && configuredColumn > 0
+    ? configuredColumn
+    : DEFAULT_AMOUNT_ALIGNMENT_COLUMN;
+
   return createCharacterPosition(
     Math.max(
       POSTING_INDENT + safeLength + MIN_AMOUNT_SPACING,
-      DEFAULT_AMOUNT_ALIGNMENT_COLUMN,
+      minimumColumn,
     ),
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a user-configurable minimum column for amount alignment and applies it across formatting and Smart Tab behavior.
> 
> - Adds `hledger.formatting.amountAlignmentColumn` (default `40`, range `20-120`) in `package.json`
> - Updates `formattingUtils.calculateAlignmentColumn` to accept a configured minimum; adds tests
> - Applies configured column in `HLedgerConfig.getAmountAlignmentColumn()` and `HLedgerTabCommand` (empty docs use configured value; document alignment respects configured minimum)
> - Updates tests for `HLedgerTabCommand` and adds comprehensive tests for formatting utils
> - Documents the setting and behavior in `README.md`, `docs/user-guide.md`, and notes in `CLAUDE.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c88335df4301c31c0f5f2281bf6469e62d3efac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->