### PR TITLE
feat: update grammar syntax for currency

### DIFF
--- a/src/extension/__tests__/__snapshots__/grammar.snapshot.test.ts.snap
+++ b/src/extension/__tests__/__snapshots__/grammar.snapshot.test.ts.snap
@@ -353,10 +353,8 @@ Line:     Assets:Checking             $1000.00
     Scopes: source.hledger, meta.posting.with-amount.hledger, entity.name.type.account.hledger
   Token: "$"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.prefix.hledger, entity.name.type.commodity.hledger
-  Token: "100"
+  Token: "1000.00"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.prefix.hledger, constant.numeric.amount.hledger
-  Token: "0.00"
-    Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.suffix.hledger, constant.numeric.amount.hledger
 
 Line:     Equity:Opening
   Token: "Equity:Opening"
@@ -562,9 +560,7 @@ exports[`Grammar Snapshot Tests Transaction Snapshots should tokenize periodic t
 Line:     Expenses:Rent              1000 USD
   Token: "Expenses:Rent"
     Scopes: source.hledger, meta.posting.with-amount.hledger, entity.name.type.account.hledger
-  Token: "100"
-    Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.suffix.hledger, constant.numeric.amount.hledger
-  Token: "0"
+  Token: "1000"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.suffix.hledger, constant.numeric.amount.hledger
   Token: "USD"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.suffix.hledger, entity.name.type.commodity.hledger
@@ -671,9 +667,7 @@ Line:     Assets:Cash             -$1500
     Scopes: source.hledger, meta.posting.with-amount.hledger
   Token: "$"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.prefix.hledger, entity.name.type.commodity.hledger
-  Token: "150"
+  Token: "1500"
     Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.prefix.hledger, constant.numeric.amount.hledger
-  Token: "0"
-    Scopes: source.hledger, meta.posting.with-amount.hledger, meta.amount.suffix.hledger, constant.numeric.amount.hledger
 "
 `;

--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -130,7 +130,7 @@
       "patterns": [
         {
           "name": "meta.amount.suffix.hledger",
-          "match": "([-+]?(?:\\d{1,3}(?:[\\s,']\\d{3})*|\\d+)(?:[.,]\\d+)?)(?:\\s+([\\p{Sc}]|[\\p{L}][\\p{L}\\p{N}]*\\b|\"[^\"]+\"))?",
+          "match": "([-+]?(?:\\d{1,3}(?:[\\s,']\\d{3})+|\\d+)(?:[.,]\\d+)?)(?:\\s+([\\p{Sc}]|[\\p{L}][\\p{L}\\p{N}]*\\b|\"[^\"]+\"))?",
           "captures": {
             "1": {
               "name": "constant.numeric.amount.hledger"
@@ -142,7 +142,7 @@
         },
         {
           "name": "meta.amount.prefix.hledger",
-          "match": "([\\p{Sc}]|[\\p{L}][\\p{L}\\p{N}]*|\"[^\"]+\")\\s*([-+]?(?:\\d{1,3}(?:[\\s,']\\d{3})*|\\d+)(?:[.,]\\d+)?)",
+          "match": "([\\p{Sc}]|[\\p{L}][\\p{L}\\p{N}]*|\"[^\"]+\")\\s*([-+]?(?:\\d{1,3}(?:[\\s,']\\d{3})+|\\d+)(?:[.,]\\d+)?)",
           "captures": {
             "1": {
               "name": "entity.name.type.commodity.hledger"


### PR DESCRIPTION
Closed: #57 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves currency/amount tokenization and updates tests.
> 
> - Refines `syntaxes/hledger.tmLanguage.json` regexes:
>   - Split prefix/suffix `meta.amount.*` to tokenize `\p{Sc}` currency symbols (e.g., `$`, `€`, `¥`, `£`) separately from digits
>   - Tighten `commodity` to single symbol or letter sequences only; adjust in balance assertions (`==`) and price assignments (`=`)
>   - Ensure thousand-separator groups don’t split plain amounts (e.g., `$1000.00`, `$1500`)
> - Adds unit tests in `grammar.test.ts` covering currency-symbol separation, negatives, thousand separators, quoted and suffix commodities, and amounts without separators; updates snapshots accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ead1fbead2bed0ef253f765e0db02a529912ea8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->