### PR TITLE
fix: correctly parse date/date2 tags with space after colon

### DIFF
--- a/src/extension/diagnostics/HLedgerDiagnosticsProvider.ts
+++ b/src/extension/diagnostics/HLedgerDiagnosticsProvider.ts
@@ -237,7 +237,8 @@ export class HLedgerDiagnosticsProvider implements vscode.Disposable {
         // In hledger, a tag is defined as: word followed by colon (tag: or tag:value)
         // Words without colons are just comments, not tags
         // Special tags like date: and date2: MUST have a value
-        const specialTagPattern = /\b(date2?):(\s*)(?=[,\s]|$)/g;
+        // Tag value ends at comma or end of line, space after colon is optional
+        const specialTagPattern = /\b(date2?):\s*([^,]*)/g;
         const matches = Array.from(commentContent.matchAll(specialTagPattern));
 
         if (matches.length > 0) {
@@ -246,10 +247,10 @@ export class HLedgerDiagnosticsProvider implements vscode.Disposable {
                 return undefined;
             }
             const tagName = firstMatch[1];
-            const tagValue = firstMatch[2];
+            const tagValue = firstMatch[2]?.trim() ?? '';
 
             // date: and date2: tags must have a value
-            if (tagName && (!tagValue || tagValue.trim() === '')) {
+            if (tagName && tagValue === '') {
                 const commentStartIndex = commentMatch.index ?? 0;
                 const commentPrefixLength = commentMatch[0].indexOf(commentContent);
                 const startPos = commentStartIndex + commentPrefixLength + (firstMatch.index ?? 0);

--- a/src/extension/diagnostics/__tests__/HLedgerDiagnosticsProvider.test.ts
+++ b/src/extension/diagnostics/__tests__/HLedgerDiagnosticsProvider.test.ts
@@ -317,6 +317,88 @@ account Assets
             expect(tagDiags.length).toBe(0);
         });
 
+        test('accepts date: tag with space before value', () => {
+            const content = `
+2024-01-01 Test  ; date: 2024-01-15
+    Expenses:Food  $10.00
+    Assets:Cash  -$10.00
+`;
+            config.parseContent(content, '/test');
+
+            const document = new MockTextDocument(content.split('\n'), {
+                uri: vscode.Uri.file('/test/test.journal'),
+                languageId: 'hledger'
+            });
+
+            provider['validateDocument'](document);
+
+            const diagnostics = provider.diagnosticCollection.get(document.uri);
+            const tagDiags = diagnostics?.filter(d => d.code === 'invalid-tag-format') ?? [];
+            expect(tagDiags.length).toBe(0);
+        });
+
+        test('accepts date2: tag with space before value', () => {
+            const content = `
+2024-01-01 Test  ; date2: 2024-01-20
+    Expenses:Food  $10.00
+    Assets:Cash  -$10.00
+`;
+            config.parseContent(content, '/test');
+
+            const document = new MockTextDocument(content.split('\n'), {
+                uri: vscode.Uri.file('/test/test.journal'),
+                languageId: 'hledger'
+            });
+
+            provider['validateDocument'](document);
+
+            const diagnostics = provider.diagnosticCollection.get(document.uri);
+            const tagDiags = diagnostics?.filter(d => d.code === 'invalid-tag-format') ?? [];
+            expect(tagDiags.length).toBe(0);
+        });
+
+        test('warns about date: tag with only spaces after colon', () => {
+            const content = `
+2024-01-01 Test  ; date:
+    Expenses:Food  $10.00
+    Assets:Cash  -$10.00
+`;
+            config.parseContent(content, '/test');
+
+            const document = new MockTextDocument(content.split('\n'), {
+                uri: vscode.Uri.file('/test/test.journal'),
+                languageId: 'hledger'
+            });
+
+            provider['validateDocument'](document);
+
+            const diagnostics = provider.diagnosticCollection.get(document.uri);
+            const tagDiag = diagnostics?.find(d => d.message.includes("date:"));
+            expect(tagDiag).toBeDefined();
+            expect(tagDiag?.severity).toBe(vscode.DiagnosticSeverity.Warning);
+            expect(tagDiag?.message).toContain('requires a value');
+        });
+
+        test('accepts date tag with value followed by comma and another tag', () => {
+            const content = `
+2024-01-01 Test  ; date: 2024-01-15, project:work
+    Expenses:Food  $10.00
+    Assets:Cash  -$10.00
+`;
+            config.parseContent(content, '/test');
+
+            const document = new MockTextDocument(content.split('\n'), {
+                uri: vscode.Uri.file('/test/test.journal'),
+                languageId: 'hledger'
+            });
+
+            provider['validateDocument'](document);
+
+            const diagnostics = provider.diagnosticCollection.get(document.uri);
+            const tagDiags = diagnostics?.filter(d => d.code === 'invalid-tag-format') ?? [];
+            expect(tagDiags.length).toBe(0);
+        });
+
         test('no warning for regular tags without values', () => {
             // Regular tags (not date/date2) can be without value
             const content = `


### PR DESCRIPTION
The specialTagPattern regex was incorrectly matching empty values when a space followed the colon (e.g., "date: 2024-01-15"). The lookahead `(?=[,\s]|$)` matched the space, causing the value capture group to be empty and triggering a false positive warning.

Changed regex from `/\b(date2?):(\s*)(?=[,\s]|$)/g` to `/\b(date2?):\s*([^,]*)/g` which properly captures the tag value up to a comma or end of line, then trims it for validation.

Fixes #68