### PR TITLE
fix: correct diagnostic position for undefined accounts

### DIFF
--- a/src/extension/diagnostics/HLedgerDiagnosticsProvider.ts
+++ b/src/extension/diagnostics/HLedgerDiagnosticsProvider.ts
@@ -174,7 +174,7 @@ export class HLedgerDiagnosticsProvider implements vscode.Disposable {
         const isDefined = this.isAccountDefinedOrHasDefinedParent(accountName, definedAccounts);
 
         if (!isDefined) {
-            // Вычисляем позицию аккаунта после начальных пробелов
+            // Calculate account position after leading spaces
             const leadingSpacesMatch = lineText.match(/^(\s+)/);
             const matchStart = leadingSpacesMatch?.[1] ? leadingSpacesMatch[1].length : 0;
             const matchLength = accountName.length;


### PR DESCRIPTION
Fix the underline position for undefined account warnings to appear under the account name instead of shifted to the right.

  - Calculate account position after leading spaces instead of using
    postingMatch.index which includes the spaces
  - Fix regex to match postings without amounts using (?:\s{2,}|$)
  - Add proper TypeScript null checking with optional chaining

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust a regex and range calculation for editor diagnostics, without affecting parsing of amounts, balance checks, or any persisted data.
> 
> **Overview**
> Fixes the `undefined-account` warning range so the underline starts at the account name (after indentation) rather than being shifted by leading whitespace.
> 
> Updates the posting-line regex in `validateAccountDefinition` to also match postings that end right after the account name (no amount), and tightens null/position handling when computing the diagnostic range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 690154509235eb8f4a4a36e2285ef6020beb9cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->