### PR TITLE
fix: updated account name regex to better reflect hledger spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,6 +232,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2631,6 +2632,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -3079,6 +3081,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3519,6 +3522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4537,6 +4541,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5971,6 +5976,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10000,6 +10006,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/extension/__tests__/syntax-highlighting.test.ts
+++ b/src/extension/__tests__/syntax-highlighting.test.ts
@@ -102,6 +102,24 @@ const syntaxTestCases: SyntaxTestCase[] = [
       amount: 'constant.numeric.amount.hledger',
       commodity: 'entity.name.type.commodity.hledger'
     }
+  },
+  {
+    description: 'Permissive account name as per hledger spec',
+    line: '    Expenses:Some account (~`@#$%^&*_-+={}[]|,.<>?/"\'\\)    100 USD',
+    expectedScopes: {
+      account: 'entity.name.type.account.expenses.hledger',
+      amount: 'constant.numeric.amount.hledger',
+      commodity: 'entity.name.type.commodity.hledger'
+    }
+  },
+  {
+    description: 'Permissive generic account name as per hledger spec',
+    line: '    E(~`@#$%^&*_-+={}[]|,.<>?/"\'\\):Some account (~`@#$%^&*_-+={}[]|,.<>?/"\'\\)    100 USD',
+    expectedScopes: {
+      account: 'entity.name.type.account.hledger',
+      amount: 'constant.numeric.amount.hledger',
+      commodity: 'entity.name.type.commodity.hledger'
+    }
   }
 ];
 
@@ -128,7 +146,7 @@ describe('Syntax Highlighting Tests', () => {
 
         // Verify account name follows hledger rules
         assert.ok(
-          /^[\p{L}][\p{L}\p{N}\s_-]*(?::[\p{L}][\p{L}\p{N}\s_-]*)*$/u.test(accountName) ||
+          /^[\p{L}]([^:;\s]|\s(?!\s))*(?::[\p{L}]([^:;\s]|\s(?!\s))*)*$/u.test(accountName) ||
           /^\([^)]+\)$/.test(accountName) ||
           /^\[[^\]]+\]$/.test(accountName),
           `Account name "${accountName}" should be valid in: ${testCase.description}`
@@ -162,12 +180,12 @@ describe('Syntax Highlighting Tests', () => {
   test('Account name regex patterns should handle spaces correctly', () => {
     // Test the individual account patterns
     const accountPatterns = [
-      { name: 'assets', pattern: /\b(Assets?|Активы)(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u },
-      { name: 'expenses', pattern: /\b(Expenses?|Расходы)(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u },
-      { name: 'liabilities', pattern: /\b(Liabilit(?:y|ies)|Пассивы)(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u },
-      { name: 'equity', pattern: /\b(Equity|Собственные)(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u },
-      { name: 'income', pattern: /\b(Income|Revenue|Доходы)(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u },
-      { name: 'generic', pattern: /[\p{L}][\p{L}\p{N}\s_-]*(?::[\p{L}][\p{L}\p{N}\s_-]*)*/u }
+      { name: 'assets', pattern: /\b(Assets?|Активы)(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u },
+      { name: 'expenses', pattern: /\b(Expenses?|Расходы)(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u },
+      { name: 'liabilities', pattern: /\b(Liabilit(?:y|ies)|Пассивы)(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u },
+      { name: 'equity', pattern: /\b(Equity|Собственные)(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u },
+      { name: 'income', pattern: /\b(Income|Revenue|Доходы)(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u },
+      { name: 'generic', pattern: /[\p{L}]([^:;\s]|\s(?!\s))*(?::[\p{L}]([^:;\s]|\s(?!\s))*)*/u }
     ];
 
     const testAccounts = [
@@ -211,7 +229,7 @@ describe('hledger Specification Compliance', () => {
       'Assets:Банковский Счет'
     ];
 
-    const accountPattern = /^[\p{L}][\p{L}\p{N}\s_-]*(?::[\p{L}][\p{L}\p{N}\s_-]*)*$/u;
+    const accountPattern = /^[\p{L}]([^:;\s]|\s(?!\s))*(?::[\p{L}]([^:;\s]|\s(?!\s))*)*$/u;
 
     for (const account of validAccounts) {
       assert.ok(

--- a/syntaxes/hledger.tmLanguage.json
+++ b/syntaxes/hledger.tmLanguage.json
@@ -183,27 +183,27 @@
         },
         {
           "name": "entity.name.type.account.assets.hledger",
-          "match": "(^|\\s)(Assets?|Активы)(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "(^|\\s)(Assets?|Активы)(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         },
         {
           "name": "entity.name.type.account.expenses.hledger",
-          "match": "(^|\\s)(Expenses?|Расходы)(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "(^|\\s)(Expenses?|Расходы)(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         },
         {
           "name": "entity.name.type.account.liabilities.hledger",
-          "match": "(^|\\s)(Liabilit(?:y|ies)|Пассивы)(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "(^|\\s)(Liabilit(?:y|ies)|Пассивы)(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         },
         {
           "name": "entity.name.type.account.equity.hledger",
-          "match": "(^|\\s)(Equity|Собственные)(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "(^|\\s)(Equity|Собственные)(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         },
         {
           "name": "entity.name.type.account.income.hledger",
-          "match": "(^|\\s)(Income|Revenue|Доходы)(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "(^|\\s)(Income|Revenue|Доходы)(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         },
         {
           "name": "entity.name.type.account.hledger",
-          "match": "[\\p{L}][\\p{L}\\p{N}\\s_-]*(?::[\\p{L}][\\p{L}\\p{N}\\s_-]*)*"
+          "match": "[\\p{L}]([^:;\\s]|\\s(?!\\s))*(?::[\\p{L}]([^:;\\s]|\\s(?!\\s))*)*"
         }
       ]
     },


### PR DESCRIPTION
Updated the regex for account names to better match what is supported as per the [hledger spec](https://hledger.org/1.51/hledger.html#account-names). This will allow for more variety in account names and eliminate false positive syntax errors resulting from these alternative names.

fix #72