### PR TITLE
fix(deps): bump tmp to 0.2.6 to fix path traversal (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9669,9 +9669,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#45](https://github.com/juev/hledger-vscode/security/dependabot/45).

Bumps the transitive `tmp` dependency `0.2.5 → 0.2.6` to fix a path traversal vulnerability (CVE-2026-44705 / GHSA-ph9p-34f9-6g65, CWE-22, High). Versions `<0.2.6` allow escaping the intended temp directory via unsanitized `prefix`/`postfix`/`dir` options.

## Details

- `tmp` is a **transitive, dev-only** dependency, pulled in by `@vscode/vsce` and `ovsx` (VSIX build/publish tooling).
- Both parents declare `tmp: ^0.2.3`, so the patched `0.2.6` satisfies existing ranges — no breaking change, no `overrides` needed.
- Only `package-lock.json` is touched.

## Verification

- `npm audit`: no remaining `tmp` advisory
- `npx tsc --noEmit`: clean
- `npm run lint`: clean
- `npm test`: 645/645 passing
- `npm run build`: success