### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     
@@ -43,7 +43,7 @@ jobs:
       run: npx vsce package
     
     - name: Upload VSIX artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: extension-${{ matrix.node-version }}
         path: "*.vsix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -83,7 +83,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.extract_version.outputs.version }}
           body: ${{ steps.generate_notes.outputs.release_notes }}


### PR DESCRIPTION
## Summary

Updates all GitHub Actions used in CI and release workflows to their latest major versions. Every action now runs on the Node 24 Actions runtime, ahead of GitHub forcing Node 24 by default on **2026-06-02** (Node 20 removed 2026-09-16).

## Changes

| Action | Before | After | Notes |
|--------|--------|-------|-------|
| `actions/checkout` | v5 | v6 | Node 24 runtime; `fetch-depth` unchanged |
| `actions/setup-node` | v5 | v6 | Node 24 runtime; auto-cache limited to npm — we already set `cache: "npm"` |
| `actions/upload-artifact` | v6 | v7 | Node 24 runtime + ESM; new optional `archive` input, our `name`/`path`/`retention-days` unchanged |
| `softprops/action-gh-release` | v1 | v3 | Node 24 runtime; removes the Node 20 deprecation warning seen in recent releases |

## Compatibility

Reviewed release notes for each bump — no input changes were required for our usage. The `setup-node` v6 breaking change (auto-cache npm-only) is already satisfied by our explicit `cache: "npm"`.

## Verification

- [x] Both workflows pass YAML validation
- [ ] CI green on this PR