### PR TITLE
feat(security): verify minisign signature before installing LSP binary

### DIFF
--- a/src/extension/lsp/BinaryManager.ts
+++ b/src/extension/lsp/BinaryManager.ts
@@ -2,6 +2,8 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { verify as verifyMinisign } from "./minisignVerify";
+import { MINISIGN_PUBLIC_KEY } from "./signingKey";
 
 const GITHUB_REPO = "juev/hledger-lsp";
 const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
@@ -394,6 +396,32 @@ export class BinaryManager {
     return checksums;
   }
 
+  private async downloadSignature(
+    release: ReleaseInfo,
+    assetName: string
+  ): Promise<string> {
+    const sigAssetName = `${assetName}.minisig`;
+    const sigAsset = release.assets.find((a) => a.name === sigAssetName);
+    if (!sigAsset) {
+      throw new Error(
+        `No signature file (${sigAssetName}) found in release - cannot verify binary authenticity`
+      );
+    }
+
+    const response = await this.fetchWithRetry(
+      sigAsset.downloadUrl,
+      undefined,
+      API_TIMEOUT_MS
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download signature: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return response.text();
+  }
+
   private verifyChecksum(buffer: ArrayBuffer, expectedHash: string): boolean {
     const hash = crypto.createHash("sha256");
     hash.update(Buffer.from(buffer));
@@ -444,6 +472,23 @@ export class BinaryManager {
     onProgress?.(95);
     if (!this.verifyChecksum(buffer, expectedChecksum)) {
       throw new Error("Checksum verification failed - binary may be corrupted");
+    }
+
+    const signatureContent = await this.downloadSignature(
+      release,
+      expectedAssetName
+    );
+    if (
+      !verifyMinisign(
+        MINISIGN_PUBLIC_KEY,
+        signatureContent,
+        new Uint8Array(buffer)
+      )
+    ) {
+      throw new Error(
+        "Signature verification failed - binary authenticity cannot be confirmed. " +
+          "The release may have been tampered with."
+      );
     }
 
     const binaryPath = this.getBinaryPath();

--- a/src/extension/lsp/__tests__/BinaryManager.test.ts
+++ b/src/extension/lsp/__tests__/BinaryManager.test.ts
@@ -9,6 +9,11 @@ import {
   getPlatformInfo,
   getBinaryName,
 } from "../BinaryManager";
+import { verify as verifyMinisign } from "../minisignVerify";
+
+jest.mock("../minisignVerify", () => ({
+  verify: jest.fn(),
+}));
 
 function createMockHeaders(contentLength?: number) {
   return {
@@ -81,6 +86,10 @@ function makeGitHubReleaseMock(assetSuffix: string) {
           {
             name: "checksums.txt",
             browser_download_url: "https://example.com/checksums.txt",
+          },
+          {
+            name: `hledger-lsp_${assetSuffix}.minisig`,
+            browser_download_url: "https://example.com/binary.minisig",
           },
         ],
       }),
@@ -163,6 +172,7 @@ describe("BinaryManager", () => {
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hledger-lsp-test-"));
     manager = new BinaryManager(tempDir);
+    (verifyMinisign as jest.Mock).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -410,6 +420,10 @@ describe("BinaryManager", () => {
                     name: "checksums.txt",
                     browser_download_url: "https://example.com/checksums.txt",
                   },
+                  {
+                    name: `hledger-lsp_${assetSuffix}.minisig`,
+                    browser_download_url: "https://example.com/binary.minisig",
+                  },
                 ],
               }),
           });
@@ -418,6 +432,12 @@ describe("BinaryManager", () => {
           return Promise.resolve({
             ok: true,
             text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
           });
         }
         return Promise.resolve({
@@ -791,6 +811,12 @@ describe("BinaryManager", () => {
             text: () => Promise.resolve(checksumContent),
           });
         }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
         return Promise.resolve({
           ok: true,
           headers: createMockHeaders(),
@@ -836,6 +862,10 @@ describe("BinaryManager", () => {
                     name: "checksums.txt",
                     browser_download_url: "https://example.com/checksums.txt",
                   },
+                  {
+                    name: `hledger-lsp_${assetSuffix}.minisig`,
+                    browser_download_url: "https://example.com/binary.minisig",
+                  },
                 ],
               }),
           });
@@ -844,6 +874,12 @@ describe("BinaryManager", () => {
           return Promise.resolve({
             ok: true,
             text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
           });
         }
         return Promise.resolve({
@@ -976,6 +1012,12 @@ describe("BinaryManager", () => {
             text: () => Promise.resolve(checksumContent),
           });
         }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
         return Promise.resolve({
           ok: true,
           headers: createMockHeaders(binaryContent.byteLength),
@@ -1017,6 +1059,12 @@ describe("BinaryManager", () => {
             text: () => Promise.resolve(checksumContent),
           });
         }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
         return Promise.resolve({
           ok: true,
           headers: createMockHeaders(binaryContent.byteLength),
@@ -1054,6 +1102,12 @@ describe("BinaryManager", () => {
           return Promise.resolve({
             ok: true,
             text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
           });
         }
         binaryFetchCount++;
@@ -1100,6 +1154,12 @@ describe("BinaryManager", () => {
             text: () => Promise.resolve(checksumContent),
           });
         }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
         binaryFetchCount++;
         if (binaryFetchCount === 1) {
           return Promise.resolve({
@@ -1124,6 +1184,197 @@ describe("BinaryManager", () => {
       expect(binaryFetchCount).toBe(2);
       expect(await manager.isInstalled()).toBe(true);
       jest.useRealTimers();
+    });
+  });
+
+  describe("signature verification", () => {
+    it("rejects binary when signature verification fails", async () => {
+      (verifyMinisign as jest.Mock).mockReturnValue(false);
+
+      const binaryContent = Buffer.alloc(2048, "x");
+      const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
+      const checksum = computeSha256(binaryContent);
+      const checksumContent = `${checksum}  hledger-lsp_${assetSuffix}\n`;
+
+      const mockFetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.resolve(makeGitHubReleaseMock(assetSuffix));
+        }
+        if (url.includes("checksums.txt")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          headers: createMockHeaders(binaryContent.byteLength),
+          arrayBuffer: () =>
+            Promise.resolve(
+              binaryContent.buffer.slice(
+                binaryContent.byteOffset,
+                binaryContent.byteOffset + binaryContent.byteLength
+              )
+            ),
+        });
+      });
+
+      manager = new BinaryManager(tempDir, mockFetch);
+
+      await expect(manager.download()).rejects.toThrow(
+        /Signature verification failed/
+      );
+      expect(await manager.isInstalled()).toBe(false);
+    });
+
+    it("rejects binary when .minisig asset is missing from release", async () => {
+      const binaryContent = Buffer.alloc(2048, "x");
+      const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
+      const checksum = computeSha256(binaryContent);
+      const checksumContent = `${checksum}  hledger-lsp_${assetSuffix}\n`;
+
+      const mockFetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                tag_name: "v0.1.0",
+                assets: [
+                  {
+                    name: `hledger-lsp_${assetSuffix}`,
+                    browser_download_url: "https://example.com/binary",
+                  },
+                  {
+                    name: "checksums.txt",
+                    browser_download_url: "https://example.com/checksums.txt",
+                  },
+                ],
+              }),
+          });
+        }
+        if (url.includes("checksums.txt")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(checksumContent),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          headers: createMockHeaders(binaryContent.byteLength),
+          arrayBuffer: () =>
+            Promise.resolve(
+              binaryContent.buffer.slice(
+                binaryContent.byteOffset,
+                binaryContent.byteOffset + binaryContent.byteLength
+              )
+            ),
+        });
+      });
+
+      manager = new BinaryManager(tempDir, mockFetch);
+
+      await expect(manager.download()).rejects.toThrow(
+        /No signature file .* found in release/
+      );
+      expect(await manager.isInstalled()).toBe(false);
+    });
+
+    it("rejects binary when .minisig download fails", async () => {
+      const binaryContent = Buffer.alloc(2048, "x");
+      const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
+      const checksum = computeSha256(binaryContent);
+      const checksumContent = `${checksum}  hledger-lsp_${assetSuffix}\n`;
+
+      const mockFetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.resolve(makeGitHubReleaseMock(assetSuffix));
+        }
+        if (url.includes("checksums.txt")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          headers: createMockHeaders(binaryContent.byteLength),
+          arrayBuffer: () =>
+            Promise.resolve(
+              binaryContent.buffer.slice(
+                binaryContent.byteOffset,
+                binaryContent.byteOffset + binaryContent.byteLength
+              )
+            ),
+        });
+      });
+
+      manager = new BinaryManager(tempDir, mockFetch);
+
+      await expect(manager.download()).rejects.toThrow(
+        /Failed to download signature/
+      );
+      expect(await manager.isInstalled()).toBe(false);
+    });
+
+    it("does not write binary to disk when signature is invalid", async () => {
+      (verifyMinisign as jest.Mock).mockReturnValue(false);
+
+      const binaryContent = Buffer.alloc(2048, "x");
+      const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
+      const checksum = computeSha256(binaryContent);
+      const checksumContent = `${checksum}  hledger-lsp_${assetSuffix}\n`;
+
+      const mockFetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes("api.github.com")) {
+          return Promise.resolve(makeGitHubReleaseMock(assetSuffix));
+        }
+        if (url.includes("checksums.txt")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(checksumContent),
+          });
+        }
+        if (url.includes(".minisig")) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve("untrusted comment: test\nsig\ntrusted comment: ts\nglobalsig"),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          headers: createMockHeaders(binaryContent.byteLength),
+          arrayBuffer: () =>
+            Promise.resolve(
+              binaryContent.buffer.slice(
+                binaryContent.byteOffset,
+                binaryContent.byteOffset + binaryContent.byteLength
+              )
+            ),
+        });
+      });
+
+      manager = new BinaryManager(tempDir, mockFetch);
+
+      await expect(manager.download()).rejects.toThrow();
+
+      const binaryPath = manager.getBinaryPath();
+      expect(fs.existsSync(binaryPath)).toBe(false);
+      const versionPath = path.join(tempDir, "version.txt");
+      expect(fs.existsSync(versionPath)).toBe(false);
     });
   });
 });

--- a/src/extension/lsp/__tests__/minisignVerify.test.ts
+++ b/src/extension/lsp/__tests__/minisignVerify.test.ts
@@ -1,0 +1,154 @@
+import * as crypto from "crypto";
+import { verify } from "../minisignVerify";
+
+const SIG_ALGO = Buffer.from("Ed");
+const KEY_ID = Buffer.from("0102030405060708", "hex");
+
+function rawPublicKeyFromKeyObject(key: crypto.KeyObject): Buffer {
+  const spki = key.export({ format: "der", type: "spki" });
+  // SPKI DER for Ed25519: 12-byte prefix + 32-byte raw key
+  return spki.subarray(spki.length - 32);
+}
+
+function toMinisignPublicKey(rawPk: Buffer): string {
+  return Buffer.concat([SIG_ALGO, KEY_ID, rawPk]).toString("base64");
+}
+
+function buildMinisig(
+  privateKey: crypto.KeyObject,
+  message: Buffer,
+  trustedComment: string
+): string {
+  const signature = crypto.sign(null, message, privateKey);
+  const globalMsg = Buffer.concat([
+    signature,
+    Buffer.from(trustedComment, "utf-8"),
+  ]);
+  const globalSig = crypto.sign(null, globalMsg, privateKey);
+
+  const sigLine = Buffer.concat([SIG_ALGO, KEY_ID, signature]).toString(
+    "base64"
+  );
+  const globalSigLine = globalSig.toString("base64");
+
+  return [
+    "untrusted comment: test signature",
+    sigLine,
+    `trusted comment: ${trustedComment}`,
+    globalSigLine,
+  ].join("\n");
+}
+
+describe("minisignVerify", () => {
+  let publicKey: crypto.KeyObject;
+  let privateKey: crypto.KeyObject;
+  let minisignPk: string;
+
+  beforeEach(() => {
+    const pair = crypto.generateKeyPairSync("ed25519");
+    publicKey = pair.publicKey;
+    privateKey = pair.privateKey;
+    minisignPk = toMinisignPublicKey(rawPublicKeyFromKeyObject(publicKey));
+  });
+
+  it("accepts a valid signature", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildMinisig(privateKey, message, "timestamp:1234\tfile:test");
+
+    expect(verify(minisignPk, minisig, message)).toBe(true);
+  });
+
+  it("rejects a signature over a different message", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildMinisig(privateKey, message, "timestamp:1234\tfile:test");
+
+    expect(verify(minisignPk, minisig, Buffer.from("tampered"))).toBe(false);
+  });
+
+  it("rejects a signature from a different key", () => {
+    const message = Buffer.from("hello world");
+    const otherPair = crypto.generateKeyPairSync("ed25519");
+    const minisig = buildMinisig(otherPair.privateKey, message, "timestamp:1234");
+
+    expect(verify(minisignPk, minisig, message)).toBe(false);
+  });
+
+  it("rejects when key ID does not match", () => {
+    const message = Buffer.from("hello world");
+    const signature = crypto.sign(null, message, privateKey);
+    const wrongKeyId = Buffer.from("ffffffffffffffff", "hex");
+    const sigLine = Buffer.concat([SIG_ALGO, wrongKeyId, signature]).toString(
+      "base64"
+    );
+    const globalMsg = Buffer.concat([
+      signature,
+      Buffer.from("timestamp:1234", "utf-8"),
+    ]);
+    const globalSig = crypto.sign(null, globalMsg, privateKey);
+    const minisig = [
+      "untrusted comment: test",
+      sigLine,
+      "trusted comment: timestamp:1234",
+      globalSig.toString("base64"),
+    ].join("\n");
+
+    expect(verify(minisignPk, minisig, message)).toBe(false);
+  });
+
+  it("rejects when global signature is invalid", () => {
+    const message = Buffer.from("hello world");
+    const signature = crypto.sign(null, message, privateKey);
+    const sigLine = Buffer.concat([SIG_ALGO, KEY_ID, signature]).toString(
+      "base64"
+    );
+    const minisig = [
+      "untrusted comment: test",
+      sigLine,
+      "trusted comment: timestamp:1234",
+      Buffer.alloc(64).toString("base64"),
+    ].join("\n");
+
+    expect(verify(minisignPk, minisig, message)).toBe(false);
+  });
+
+  it("rejects truncated minisig content", () => {
+    expect(verify(minisignPk, "only one line", Buffer.from("x"))).toBe(false);
+    expect(verify(minisignPk, "", Buffer.from("x"))).toBe(false);
+  });
+
+  it("rejects invalid public key base64", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildMinisig(privateKey, message, "timestamp:1234");
+
+    expect(verify("not-valid-base64!!!", minisig, message)).toBe(false);
+  });
+
+  it("rejects when trusted comment prefix is missing", () => {
+    const message = Buffer.from("hello world");
+    const signature = crypto.sign(null, message, privateKey);
+    const sigLine = Buffer.concat([SIG_ALGO, KEY_ID, signature]).toString(
+      "base64"
+    );
+    const globalMsg = Buffer.concat([
+      signature,
+      Buffer.from("timestamp:1234", "utf-8"),
+    ]);
+    const globalSig = crypto.sign(null, globalMsg, privateKey);
+    const minisig = [
+      "untrusted comment: test",
+      sigLine,
+      "wrong prefix: timestamp:1234",
+      globalSig.toString("base64"),
+    ].join("\n");
+
+    expect(verify(minisignPk, minisig, message)).toBe(false);
+  });
+
+  it("handles CRLF line endings", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildMinisig(privateKey, message, "timestamp:1234");
+    const crlfMinisig = minisig.replace(/\n/g, "\r\n");
+
+    expect(verify(minisignPk, crlfMinisig, message)).toBe(true);
+  });
+});

--- a/src/extension/lsp/minisignVerify.ts
+++ b/src/extension/lsp/minisignVerify.ts
@@ -1,0 +1,78 @@
+import * as crypto from "crypto";
+
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const SIG_ALGO = Buffer.from("Ed");
+const KEY_ID_LEN = 8;
+const SIG_LEN = 64;
+const PK_LEN = 32;
+const TRUSTED_COMMENT_PREFIX = "trusted comment: ";
+
+function toEd25519KeyObject(rawPk: Buffer): crypto.KeyObject {
+  return crypto.createPublicKey({
+    key: Buffer.concat([ED25519_SPKI_PREFIX, rawPk]),
+    format: "der",
+    type: "spki",
+  });
+}
+
+/**
+ * Verify a minisign signature (.minisig content) over a message.
+ *
+ * Minisign uses Ed25519. The .minisig format:
+ *   untrusted comment: ...
+ *   <base64: 2B algo "Ed" + 8B keyId + 64B signature>
+ *   trusted comment: ...
+ *   <base64: 64B global signature over (signature || trustedComment)>
+ *
+ * Both the main signature (over the message) and the global signature
+ * (over signature bytes + trusted comment) must verify.
+ */
+export function verify(
+  publicKeyBase64: string,
+  minisigContent: string,
+  message: Uint8Array
+): boolean {
+  try {
+    const lines = minisigContent
+      .split("\n")
+      .map((l) => l.trimEnd())
+      .filter((l) => l.length > 0);
+    if (lines.length < 4) return false;
+
+    const sigLine = lines[1];
+    const commentLine = lines[2];
+    const globalSigLine = lines[3];
+    if (sigLine === undefined || commentLine === undefined || globalSigLine === undefined)
+      return false;
+
+    const pkRaw = Buffer.from(publicKeyBase64.trim(), "base64");
+    if (pkRaw.length < 2 + KEY_ID_LEN + PK_LEN) return false;
+    if (!pkRaw.subarray(0, 2).equals(SIG_ALGO)) return false;
+    const keyId = pkRaw.subarray(2, 2 + KEY_ID_LEN);
+    const publicKey = toEd25519KeyObject(
+      pkRaw.subarray(2 + KEY_ID_LEN, 2 + KEY_ID_LEN + PK_LEN)
+    );
+
+    const sigRaw = Buffer.from(sigLine, "base64");
+    if (sigRaw.length < 2 + KEY_ID_LEN + SIG_LEN) return false;
+    if (!sigRaw.subarray(0, 2).equals(SIG_ALGO)) return false;
+    if (!sigRaw.subarray(2, 2 + KEY_ID_LEN).equals(keyId)) return false;
+    const signature = sigRaw.subarray(2 + KEY_ID_LEN, 2 + KEY_ID_LEN + SIG_LEN);
+
+    if (!commentLine.startsWith(TRUSTED_COMMENT_PREFIX)) return false;
+    const trustedComment = commentLine.slice(TRUSTED_COMMENT_PREFIX.length);
+    const globalSig = Buffer.from(globalSigLine, "base64");
+    if (globalSig.length !== SIG_LEN) return false;
+
+    if (!crypto.verify(null, Buffer.from(message), publicKey, signature))
+      return false;
+
+    const globalMsg = Buffer.concat([
+      signature,
+      Buffer.from(trustedComment, "utf-8"),
+    ]);
+    return crypto.verify(null, globalMsg, publicKey, globalSig);
+  } catch {
+    return false;
+  }
+}

--- a/src/extension/lsp/signingKey.ts
+++ b/src/extension/lsp/signingKey.ts
@@ -1,0 +1,10 @@
+// Minisign public key for verifying hledger-lsp release signatures.
+//
+// Generated with: minisign -G -W
+// The corresponding private key is stored as the MINISIGN_PRIVATE_KEY
+// GitHub Actions secret in juev/hledger-lsp (see juev/hledger-lsp#47).
+//
+// To rotate: generate a new key pair, update this constant and the
+// GitHub Actions secret in the same release cycle.
+export const MINISIGN_PUBLIC_KEY =
+  "RWQ_PLACEHOLDER_REPLACE_AFTER_KEY_GENERATION";

--- a/src/extension/lsp/signingKey.ts
+++ b/src/extension/lsp/signingKey.ts
@@ -7,4 +7,4 @@
 // To rotate: generate a new key pair, update this constant and the
 // GitHub Actions secret in the same release cycle.
 export const MINISIGN_PUBLIC_KEY =
-  "RWQ_PLACEHOLDER_REPLACE_AFTER_KEY_GENERATION";
+  "RWQrqo1HFNu6atxzZuaGpH+4mY0MvXUFdu8TmNhyCtsLnp3Seo3YhjP1";


### PR DESCRIPTION
## Summary

The extension verified SHA-256 checksums from `checksums.txt` in the same GitHub release as the binary. This proves integrity (no CDN/transit tampering) but not authenticity: a compromised release pipeline can replace both the binary and its checksum simultaneously, yielding silent RCE on all clients with `checkForUpdates: true` (default).

This PR adds **minisign (Ed25519) signature verification** before the binary is written to disk. The verification uses Node.js built-in `crypto` — zero new npm dependencies.

## Changes

### New files

- **`src/extension/lsp/minisignVerify.ts`** — pure minisign signature verification on Node.js `crypto.verify()`. Parses the `.minisig` format (algo + keyId + Ed25519 signature + trusted comment + global signature) and verifies both the main and global signatures.
- **`src/extension/lsp/signingKey.ts`** — public key placeholder. Replace `RWQ_PLACEHOLDER_REPLACE_AFTER_KEY_GENERATION` with the real minisign public key after generating the key pair (see juev/hledger-lsp#47).
- **`src/extension/lsp/__tests__/minisignVerify.test.ts`** — unit tests using real Ed25519 signatures generated via Node.js crypto (no external tools needed).

### Modified files

- **`src/extension/lsp/BinaryManager.ts`** — `download()` now fetches `${assetName}.minisig` from the release and verifies the signature after checksum verification, before writing to disk. Missing or invalid signature → install rejected.
- **`src/extension/lsp/__tests__/BinaryManager.test.ts`** — updated existing download tests to include `.minisig` assets; added 4 new tests for signature verification failures.

## Verification flow

```
getLatestRelease()
  → downloadChecksums()       ← integrity (checksums.txt)
  → downloadBinaryWithRetry()
  → verifyChecksum()          ← SHA-256 against checksums.txt
  → downloadSignature()       ← NEW: fetch .minisig
  → verifyMinisign()          ← NEW: Ed25519 authenticity check
  → write to disk             ← only if both pass
```

## Trust model

| Attacker capability | Result |
|---|---|
| Replace binary + checksums.txt in release | Signature mismatch → install rejected |
| Replace binary + checksums.txt + .minisig | Impossible without private key |
| Compromise GitHub Actions secret | Can sign — requires CI-level compromise |

## Verification

```bash
npm test        # 672 tests, 31 suites — all pass
npm run lint    # clean
npx tsc --noEmit  # clean
```

## Related

- Closes #213
- Requires: juev/hledger-lsp#47 (signing step in release pipeline)

## Post-merge checklist

1. Generate minisign key pair: `minisign -G -W -f minisign.key`
2. Replace `MINISIGN_PUBLIC_KEY` in `signingKey.ts` with the real public key
3. Add `MINISIGN_PRIVATE_KEY` (base64-encoded private key) as GitHub Actions secret in `juev/hledger-lsp`
4. Merge juev/hledger-lsp#47 (signing step in release pipeline)
5. Publish a new hledger-lsp release with signed artifacts
6. Verify the extension can download and verify the signed binary
