### PR TITLE
fix(lsp): accept Windows paths in hledger.lsp.path setting

### DIFF
--- a/src/extension/HLedgerCliCommands.ts
+++ b/src/extension/HLedgerCliCommands.ts
@@ -3,6 +3,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import { HLedgerCliService } from "./services/HLedgerCliService";
+import { validatePathSafety } from "./security/shellValidation";
 
 export class HLedgerCliCommands implements vscode.Disposable {
   private cliService: HLedgerCliService;
@@ -180,12 +181,7 @@ export class HLedgerCliCommands implements vscode.Disposable {
    * @throws Error if path contains shell metacharacters or is inaccessible
    */
   private sanitizeJournalPath(filePath: string): string {
-    // Dangerous shell metacharacters (excluding backslash for Windows path compatibility)
-    const dangerousChars = /[;|&`$()[\]{}^"<>]/;
-
-    if (dangerousChars.test(filePath)) {
-      throw new Error(`Path contains shell metacharacters: ${filePath}`);
-    }
+    validatePathSafety(filePath);
 
     try {
       fs.accessSync(filePath, fs.constants.R_OK);

--- a/src/extension/lsp/LSPManager.ts
+++ b/src/extension/lsp/LSPManager.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import { BinaryManager } from "./BinaryManager";
 import { HLedgerLanguageClient, LanguageClientState, PayeeAccountHistoryResult } from "./HLedgerLanguageClient";
 import { hasCustomLSPPath, getCustomLSPPath } from "./lspConfig";
-import { validatePathSafety } from "../security/shellValidation";
 
 export interface LSPManagerLike {
   isServerAvailable(): Promise<boolean>;
@@ -93,7 +92,6 @@ export class LSPManager implements vscode.Disposable {
   getBinaryPath(): string {
     const customPath = getCustomLSPPath();
     if (customPath !== null) {
-      validatePathSafety(customPath);
       return customPath;
     }
     return this.binaryManager.getBinaryPath();

--- a/src/extension/lsp/__tests__/LSPManager.test.ts
+++ b/src/extension/lsp/__tests__/LSPManager.test.ts
@@ -102,7 +102,21 @@ describe("LSPManager", () => {
       expect(binaryPath).toMatch(/hledger-lsp(\.exe)?$/);
     });
 
-    it("throws when custom path contains shell metacharacters", () => {
+    it("accepts Windows-style path with backslashes", () => {
+      const vscode = require("vscode");
+      vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
+        get: (key: string) => {
+          if (key === "path") return "C:\\tools\\hledger-lsp.exe";
+          return undefined;
+        },
+      });
+
+      const manager = new LSPManager(mockContext);
+
+      expect(manager.getBinaryPath()).toBe("C:\\tools\\hledger-lsp.exe");
+    });
+
+    it("accepts path with shell metacharacters (no shell is spawned)", () => {
       const vscode = require("vscode");
       vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
         get: (key: string) => {
@@ -113,21 +127,7 @@ describe("LSPManager", () => {
 
       const manager = new LSPManager(mockContext);
 
-      expect(() => manager.getBinaryPath()).toThrow(/shell metacharacters/);
-    });
-
-    it("throws for path with ampersand", () => {
-      const vscode = require("vscode");
-      vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
-        get: (key: string) => {
-          if (key === "path") return "/path && malicious";
-          return undefined;
-        },
-      });
-
-      const manager = new LSPManager(mockContext);
-
-      expect(() => manager.getBinaryPath()).toThrow(/shell metacharacters/);
+      expect(manager.getBinaryPath()).toBe("/path/to/lsp; rm -rf /");
     });
 
     it("returns custom path when valid and set", () => {

--- a/src/extension/security/shellValidation.ts
+++ b/src/extension/security/shellValidation.ts
@@ -1,9 +1,13 @@
-// Shell metacharacter pattern for path validation
-// Prevents command injection by rejecting paths with shell special characters
-const SHELL_METACHAR_PATTERN = /[;&|`$()[\]{}^"<>#!*?~\\'\n\r]/;
+// Shell metacharacter pattern for path validation.
+// Backslash is excluded: it is the Windows path separator, not a shell
+// metacharacter in the contexts where this validation applies (execFile /
+// Executable — no shell is spawned).  Characters #, ~, ' are legitimate in
+// file paths and are also excluded.
+const SHELL_METACHAR_PATTERN = /[;|&`$()[\]{}^"<>\n\r]/;
 
 /**
- * Validates that a path doesn't contain shell metacharacters
+ * Validates that a path doesn't contain shell metacharacters.
+ * Use only where a path is interpolated into a shell command.
  * @param path - The path to validate
  * @throws Error if path contains shell metacharacters
  */


### PR DESCRIPTION
## Summary

Fixes #214.

`hledger.lsp.path` rejected any Windows-style path (`C:\tools\hledger-lsp.exe`) because `validatePathSafety` treated backslash as a shell metacharacter. The LSP binary is spawned via `vscode-languageclient` `Executable` (`command` + `args`, **no shell**), so metacharacters in the path are not a risk — the validation was both redundant and harmful.

## Changes

- **`LSPManager.getBinaryPath()`** — removed `validatePathSafety` call. The existing `fs.access(X_OK)` check in `start()` is the only meaningful validation (file exists and is executable).
- **`security/shellValidation.ts`** — updated the shared regex to exclude backslash (Windows path separator) and legitimate path characters (`#`, `~`, `'`). Added `\n`/`\r` rejection.
- **`HLedgerCliCommands.sanitizeJournalPath`** — replaced the divergent inline regex with the shared `validatePathSafety` utility. Single source of truth, no divergence.
- **Tests** — replaced "throws on shell metacharacters" tests with "accepts Windows paths" and "accepts paths with metacharacters (no shell spawned)".

## Verification

- `npm test` — 672 tests pass
- `npm run lint` — clean
- `npx tsc --noEmit` — clean

## Acceptance criteria

- [x] `hledger.lsp.path = "C:\tools\hledger-lsp.exe"` is accepted on Windows
- [x] Single shared path-validation utility; no divergence