### PR TITLE
fix(cli): rename balance report to balance sheet, add timeout and cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Insert hledger reports directly into your journals as formatted comments.
 
 **Available Commands** (via Command Palette `Ctrl+Shift+P`):
 
-- `HLedger: Insert Balance Report` - Balance sheet with assets/liabilities
+- `HLedger: Insert Balance Sheet` - Balance sheet with assets/liabilities
 - `HLedger: Insert Income Statement` - Revenue and expense summary
 - `HLedger: Insert Statistics Report` - File stats and metrics
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -699,7 +699,7 @@ Access via Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`):
 
 | Command | Description | hledger command |
 |---------|-------------|-----------------|
-| HLedger: Insert Balance Report | Balance sheet with assets/liabilities | `hledger bs` |
+| HLedger: Insert Balance Sheet | Balance sheet with assets/liabilities | `hledger bs` |
 | HLedger: Insert Income Statement | Revenue and expense summary | `hledger incomestatement` |
 | HLedger: Insert Statistics Report | File statistics and metrics | `hledger stats` |
 
@@ -751,7 +751,7 @@ Right-click in the editor to access the HLedger submenu with quick access to CLI
 
 | Command | Description |
 |---------|-------------|
-| **Insert Balance Report** | Insert `hledger bs` output as comment |
+| **Insert Balance Sheet** | Insert `hledger bs` output as comment |
 | **Insert Income Statement** | Insert `hledger is` output as comment |
 | **Insert Statistics** | Insert `hledger stats` output as comment |
 
@@ -1152,7 +1152,7 @@ All commands accessible via Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`):
 
 | Command | Title | Description |
 |---------|-------|-------------|
-| `hledger.cli.balance` | HLedger: Insert Balance Report | Insert balance sheet as comment |
+| `hledger.cli.balance` | HLedger: Insert Balance Sheet | Insert balance sheet as comment |
 | `hledger.cli.stats` | HLedger: Insert Statistics Report | Insert file statistics as comment |
 | `hledger.cli.incomestatement` | HLedger: Insert Income Statement | Insert income statement as comment |
 | `hledger.import.fromSelection` | HLedger: Import Selected Tabular Data | Import selected CSV/TSV |

--- a/package.json
+++ b/package.json
@@ -406,7 +406,7 @@
     "commands": [
       {
         "command": "hledger.cli.balance",
-        "title": "HLedger: Insert Balance Report",
+        "title": "HLedger: Insert Balance Sheet",
         "category": "HLedger",
         "when": "editorTextFocus && editorLangId == hledger"
       },

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -823,7 +823,15 @@ export const window = {
     document: null,
     edit: jest.fn(),
   },
-  withProgress: jest.fn((options, task) => task({ report: jest.fn() })),
+  withProgress: jest.fn((options, task) =>
+    task(
+      { report: jest.fn() },
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() })),
+      },
+    ),
+  ),
   createOutputChannel: jest.fn(
     (name: string): OutputChannel => ({
       name,

--- a/src/extension/HLedgerCliCommands.ts
+++ b/src/extension/HLedgerCliCommands.ts
@@ -21,8 +21,8 @@ export class HLedgerCliCommands implements vscode.Disposable {
     // No resources to dispose - cliService is disposed separately
   }
 
-  public async insertBalance(): Promise<void> {
-    await this.insertCliReport("balance");
+  public async insertBalanceSheet(): Promise<void> {
+    await this.insertCliReport("balancesheet");
   }
 
   public async insertStats(): Promise<void> {
@@ -61,39 +61,52 @@ export class HLedgerCliCommands implements vscode.Disposable {
       {
         location: vscode.ProgressLocation.Notification,
         title: `Running hledger ${command}...`,
-        cancellable: false,
+        cancellable: true,
       },
-      async () => {
+      async (_progress, token) => {
+        const abortController = new AbortController();
+        const cancelDisposable = token.onCancellationRequested(() => {
+          abortController.abort();
+        });
+
         try {
           const cliAvailable = await this.ensureCliAvailable();
           if (!cliAvailable) {
             return;
           }
 
-          // Get the journal file path
           const journalFile = this.getJournalFilePath(document);
 
-          // Execute the command
           let output: string;
           let cliCommandName: string;
           switch (command) {
-            case "balance":
-              output = await this.cliService.runBalance(journalFile);
+            case "balancesheet":
+              output = await this.cliService.runBalanceSheet(
+                journalFile,
+                [],
+                abortController.signal,
+              );
               cliCommandName = "bs";
               break;
             case "stats":
-              output = await this.cliService.runStats(journalFile);
+              output = await this.cliService.runStats(
+                journalFile,
+                abortController.signal,
+              );
               cliCommandName = "stats";
               break;
             case "incomestatement":
-              output = await this.cliService.runIncomestatement(journalFile);
+              output = await this.cliService.runIncomestatement(
+                journalFile,
+                [],
+                abortController.signal,
+              );
               cliCommandName = "incomestatement";
               break;
             default:
               throw new Error(`Unknown command: ${command}`);
           }
 
-          // Format as comment and insert
           const comment = this.cliService.formatAsComment(
             output,
             cliCommandName,
@@ -104,9 +117,17 @@ export class HLedgerCliCommands implements vscode.Disposable {
             `hledger ${cliCommandName} report inserted successfully.`,
           );
         } catch (error: unknown) {
+          if (abortController.signal.aborted) {
+            vscode.window.showInformationMessage(
+              `hledger ${command} was cancelled.`,
+            );
+            return;
+          }
           vscode.window.showErrorMessage(
             `Failed to run hledger ${command}: ${error instanceof Error ? error.message : String(error)}`,
           );
+        } finally {
+          cancelDisposable.dispose();
         }
       },
     );

--- a/src/extension/__tests__/HLedgerCliCommands.test.ts
+++ b/src/extension/__tests__/HLedgerCliCommands.test.ts
@@ -51,27 +51,27 @@ describe('HLedgerCliCommands - Progress Indicators', () => {
         delete process.env.LEDGER_FILE;
     });
 
-    it('should show progress notification during balance command execution', async () => {
+    it('should show cancellable progress notification during balance sheet command execution', async () => {
         const vscode = require('vscode');
         const withProgressSpy = jest.spyOn(vscode.window, 'withProgress');
 
         jest.spyOn(mockService, 'isHledgerAvailable').mockResolvedValue(true);
-        jest.spyOn(mockService, 'runBalance').mockResolvedValue('Balance Report');
-        jest.spyOn(mockService, 'formatAsComment').mockReturnValue('; Balance Report');
+        jest.spyOn(mockService, 'runBalanceSheet').mockResolvedValue('Balance Sheet Report');
+        jest.spyOn(mockService, 'formatAsComment').mockReturnValue('; Balance Sheet Report');
 
-        await commands.insertBalance();
+        await commands.insertBalanceSheet();
 
         expect(withProgressSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 location: vscode.ProgressLocation.Notification,
-                title: 'Running hledger balance...',
-                cancellable: false
+                title: 'Running hledger balancesheet...',
+                cancellable: true
             }),
             expect.any(Function)
         );
     });
 
-    it('should show progress notification during stats command execution', async () => {
+    it('should show cancellable progress notification during stats command execution', async () => {
         const vscode = require('vscode');
         const withProgressSpy = jest.spyOn(vscode.window, 'withProgress');
 
@@ -85,13 +85,13 @@ describe('HLedgerCliCommands - Progress Indicators', () => {
             expect.objectContaining({
                 location: vscode.ProgressLocation.Notification,
                 title: 'Running hledger stats...',
-                cancellable: false
+                cancellable: true
             }),
             expect.any(Function)
         );
     });
 
-    it('should show progress notification during incomestatement command execution', async () => {
+    it('should show cancellable progress notification during incomestatement command execution', async () => {
         const vscode = require('vscode');
         const withProgressSpy = jest.spyOn(vscode.window, 'withProgress');
 
@@ -105,7 +105,7 @@ describe('HLedgerCliCommands - Progress Indicators', () => {
             expect.objectContaining({
                 location: vscode.ProgressLocation.Notification,
                 title: 'Running hledger incomestatement...',
-                cancellable: false
+                cancellable: true
             }),
             expect.any(Function)
         );
@@ -115,12 +115,43 @@ describe('HLedgerCliCommands - Progress Indicators', () => {
         const vscode = require('vscode');
 
         jest.spyOn(mockService, 'isHledgerAvailable').mockResolvedValue(true);
-        jest.spyOn(mockService, 'runBalance').mockRejectedValue(new Error('CLI execution failed'));
+        jest.spyOn(mockService, 'runBalanceSheet').mockRejectedValue(new Error('CLI execution failed'));
 
-        await commands.insertBalance();
+        await commands.insertBalanceSheet();
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            expect.stringContaining('Failed to run hledger balance')
+            expect.stringContaining('Failed to run hledger balancesheet')
+        );
+    });
+
+    it('should show info message when command is cancelled', async () => {
+        const vscode = require('vscode');
+
+        jest.spyOn(mockService, 'isHledgerAvailable').mockResolvedValue(true);
+        jest.spyOn(mockService, 'runBalanceSheet').mockImplementation(async () => {
+            throw new Error('hledger bs was cancelled.');
+        });
+
+        // Simulate cancellation by making withProgress trigger the abort
+        vscode.window.withProgress.mockImplementationOnce(async (options: any, task: any) => {
+            const listeners: Array<() => void> = [];
+            const token = {
+                isCancellationRequested: false,
+                onCancellationRequested: jest.fn((listener: () => void) => {
+                    listeners.push(listener);
+                    return { dispose: jest.fn() };
+                }),
+            };
+            const progressPromise = task({ report: jest.fn() }, token);
+            // Trigger cancellation after the task starts
+            listeners.forEach(l => l());
+            return progressPromise;
+        });
+
+        await commands.insertBalanceSheet();
+
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+            expect.stringContaining('was cancelled')
         );
     });
 });

--- a/src/extension/__tests__/activation.test.ts
+++ b/src/extension/__tests__/activation.test.ts
@@ -35,7 +35,7 @@ jest.mock("../services/HLedgerCliService", () => ({
 jest.mock("../HLedgerCliCommands", () => ({
   HLedgerCliCommands: jest.fn().mockImplementation(() => ({
     dispose: jest.fn(),
-    insertBalance: jest.fn(),
+    insertBalanceSheet: jest.fn(),
     insertStats: jest.fn(),
     insertIncomestatement: jest.fn(),
   })),

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -173,7 +173,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Register CLI commands
     context.subscriptions.push(
       vscode.commands.registerCommand("hledger.cli.balance", async () => {
-        await cliCommands.insertBalance();
+        await cliCommands.insertBalanceSheet();
       }),
     );
 

--- a/src/extension/services/HLedgerCliService.ts
+++ b/src/extension/services/HLedgerCliService.ts
@@ -137,15 +137,26 @@ export class HLedgerCliService implements vscode.Disposable {
         }
     }
 
-    public async executeCommand(subcommand: string, journalFile: string, args: string[] = []): Promise<string> {
+    public async executeCommand(
+        subcommand: string,
+        journalFile: string,
+        args: string[] = [],
+        signal?: AbortSignal,
+    ): Promise<string> {
         const hledgerPath = await this.getHledgerPath();
         if (!hledgerPath) {
             throw new Error('hledger executable not found. Please install hledger or configure the path in settings.');
         }
 
+        const timeout = vscode.workspace.getConfiguration('hledger').get<number>('cli.timeout', 30000);
+
         try {
             const cliArgs = ['-f', journalFile, subcommand, ...args];
-            const { stdout, stderr } = await execFile(hledgerPath, cliArgs, { maxBuffer: 10 * 1024 * 1024 });
+            const { stdout, stderr } = await execFile(hledgerPath, cliArgs, {
+                maxBuffer: 10 * 1024 * 1024,
+                timeout,
+                signal,
+            });
 
             if (stderr) {
                 console.warn('hledger stderr:', stderr);
@@ -153,24 +164,33 @@ export class HLedgerCliService implements vscode.Disposable {
 
             return stdout;
         } catch (error: unknown) {
+            if (signal?.aborted) {
+                throw new Error(`hledger ${subcommand} was cancelled.`);
+            }
             if (isExecFailure(error) && error.stderr) {
                 throw createErrorWithCause(`hledger command failed: ${error.stderr}`, error);
             }
             const message = error instanceof Error ? error.message : String(error);
+            if (message.includes('ETIMEDOUT') || message.includes('timed out')) {
+                throw createErrorWithCause(
+                    `hledger ${subcommand} timed out after ${timeout}ms. Increase hledger.cli.timeout if needed.`,
+                    error,
+                );
+            }
             throw createErrorWithCause(`Failed to execute hledger command: ${message}`, error);
         }
     }
 
-    public async runBalance(journalFile: string, extraArgs: string[] = []): Promise<string> {
-        return this.executeCommand('bs', journalFile, extraArgs);
+    public async runBalanceSheet(journalFile: string, extraArgs: string[] = [], signal?: AbortSignal): Promise<string> {
+        return this.executeCommand('bs', journalFile, extraArgs, signal);
     }
 
-    public async runStats(journalFile: string): Promise<string> {
-        return this.executeCommand('stats', journalFile);
+    public async runStats(journalFile: string, signal?: AbortSignal): Promise<string> {
+        return this.executeCommand('stats', journalFile, [], signal);
     }
 
-    public async runIncomestatement(journalFile: string, extraArgs: string[] = []): Promise<string> {
-        return this.executeCommand('incomestatement', journalFile, extraArgs);
+    public async runIncomestatement(journalFile: string, extraArgs: string[] = [], signal?: AbortSignal): Promise<string> {
+        return this.executeCommand('incomestatement', journalFile, extraArgs, signal);
     }
 
     public formatAsComment(output: string, command: string): string {


### PR DESCRIPTION
## Summary

Fixes #216 — CLI report commands: wrong report name, no timeout, not cancellable.

## Changes

**Wrong report name.** The command palette title said "Insert Balance Report" but actually ran `hledger bs` (balance sheet). Renamed to "Insert Balance Sheet" across `package.json`, docs, and code (`runBalance` → `runBalanceSheet`, `insertBalance` → `insertBalanceSheet`).

**Timeout enforced.** `executeCommand` now reads `hledger.cli.timeout` (default 30s) and passes it to `execFile`. Timeout errors produce a clear message suggesting the user increase the setting.

**Cancellation enabled.** Progress notifications are now `cancellable: true`. An `AbortController` is wired to the VS Code cancellation token and its signal forwarded to `execFile`, killing the child process on cancel. Cancelled commands show an info message instead of an error.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 680/680 tests pass
- New test: cancellation shows info message instead of error
- Updated tests: all progress notifications assert `cancellable: true`