### PR TITLE
fix(keybindings): stop Enter from committing third-party inline suggestions

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,6 +248,16 @@
           "default": false,
           "description": "Enable balance check indicators on transactions (CodeLens)"
         },
+        "hledger.keybindings.enterAndSuggest": {
+          "type": "boolean",
+          "default": true,
+          "description": "Rebind Enter in hledger files to insert a newline (disable to restore default VS Code Enter behavior)"
+        },
+        "hledger.keybindings.alignAmount": {
+          "type": "boolean",
+          "default": true,
+          "description": "Rebind Tab in hledger files to align amounts via the Language Server (disable to restore default VS Code Tab behavior)"
+        },
         "hledger.completion.snippets": {
           "type": "boolean",
           "default": true,
@@ -494,19 +504,14 @@
         "when": "editorTextFocus && editorLangId == hledger && suggestWidgetVisible"
       },
       {
-        "command": "editor.action.inlineSuggest.commit",
-        "key": "enter",
-        "when": "editorTextFocus && editorLangId == hledger && inlineSuggestionVisible"
-      },
-      {
         "command": "hledger.editor.enterAndSuggest",
         "key": "enter",
-        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode"
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && config.hledger.keybindings.enterAndSuggest"
       },
       {
         "command": "hledger.editor.alignAmount",
         "key": "tab",
-        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !hasSnippetCompletions"
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
       },
       {
         "command": "hledger.editor.cycleStatus",

--- a/src/extension/commands/__tests__/enterAndSuggest.test.ts
+++ b/src/extension/commands/__tests__/enterAndSuggest.test.ts
@@ -10,7 +10,7 @@ describe("enterAndSuggest", () => {
     executeCommandMock.mockResolvedValue(undefined);
   });
 
-  it("executes default Enter then triggers inline suggestion", async () => {
+  it("inserts a newline then triggers inline suggestion", async () => {
     await enterAndSuggest();
 
     expect(executeCommandMock).toHaveBeenCalledTimes(2);

--- a/src/extension/commands/alignAmount.ts
+++ b/src/extension/commands/alignAmount.ts
@@ -12,7 +12,7 @@ interface LSPTextEdit {
   newText: string;
 }
 
-const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_TIMEOUT_MS = 600;
 
 async function fallbackTab(): Promise<void> {
   await vscode.commands.executeCommand("tab");

--- a/src/extension/commands/enterAndSuggest.ts
+++ b/src/extension/commands/enterAndSuggest.ts
@@ -4,7 +4,7 @@ export async function enterAndSuggest(): Promise<void> {
   try {
     await vscode.commands.executeCommand("type", { text: "\n" });
   } catch {
-    // type command may fail in readonly editors — proceed to trigger anyway
+    // type command may fail in readonly editors
   }
   await vscode.commands.executeCommand(
     "editor.action.inlineSuggest.trigger",


### PR DESCRIPTION
## Summary

Fixes #217.

The extension rebound Enter to `editor.action.inlineSuggest.commit` in hledger files. When Copilot/TabNine was active, this committed their ghost text instead of inserting a newline — Enter behavior became unpredictable.

## Changes

- **Remove `editor.action.inlineSuggest.commit` on Enter** — ghost text is now accepted via Tab (VS Code default). Enter always inserts a newline.
- **Reduce `alignAmount` LSP timeout** from 3000ms → 600ms so Tab falls back quickly when the server is slow or hung.
- **Add opt-out settings** `hledger.keybindings.enterAndSuggest` and `hledger.keybindings.alignAmount` (default: `true`) — set to `false` to restore default VS Code Enter/Tab behavior in hledger files.

## Verification

- `npm test` — 680 passed
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- Local manual test in Extension Development Host: Enter inserts newline, ghost text appears and is accepted via Tab, Copilot suggestions are not committed on Enter