### PR TITLE
feat(walkthrough): add reports and keybindings steps, keybinding hints in status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Transform your plain text accounting experience with powerful IDE capabilities:
 - **Auto-download** of LSP binary from GitHub releases
 - **Status bar indicator** showing LSP state (Running, Error, etc.)
 - **Output channel** for diagnostics (`View → Output → HLedger`)
-- **Guided walkthrough** for new users (Command Palette → "Get Started: HLedger")
+- **Guided walkthrough** for new users (Command Palette → "Get Started: HLedger") — covers LSP setup, journal editing, CSV import, CLI reports, and keyboard shortcuts
 - **CodeLens** balance check indicators on transactions (opt-in)
 - Cross-platform support (macOS, Linux, Windows)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1186,6 +1186,16 @@ All commands accessible via Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`):
 
 **On-type formatting** (Enter/Tab) is handled by the Language Server when `editor.formatOnType` is enabled.
 
+### Status Bar Hints
+
+When editing an hledger file, the status bar shows a quick reference for the most useful keybindings:
+
+```
+⌘K S: status · Tab: align · Enter: suggest
+```
+
+This hint is visible only in hledger files and requires no configuration.
+
 ### Completion Trigger Characters
 
 These characters automatically trigger completions:

--- a/docs/walkthrough/keybindings.md
+++ b/docs/walkthrough/keybindings.md
@@ -1,0 +1,51 @@
+# Keyboard Shortcuts
+
+The extension provides keybindings for common editing tasks in hledger files.
+
+## Status keybindings
+
+Set or cycle the transaction/posting status marker (`*`, `!`, or none):
+
+| Key (macOS) | Key (Win/Linux) | Action |
+|-------------|-----------------|--------|
+| `Cmd+K S` | `Ctrl+K S` | Cycle status (unmarked → pending → cleared) |
+| `Cmd+K 0` | `Ctrl+K 0` | Set status to unmarked |
+| `Cmd+K 1` | `Ctrl+K 1` | Set status to pending (`!`) |
+| `Cmd+K 2` | `Ctrl+K 2` | Set status to cleared (`*`) |
+
+Example:
+
+```hledger
+2025-01-15 * Grocery Store        ; ← cleared
+    Expenses:Food:Groceries  $45.50
+    Assets:Bank:Checking    -$45.50
+```
+
+## Tab: align amount
+
+Press **Tab** after typing an account name to move the cursor to the amount column. Amounts are aligned automatically on save when `editor.formatOnType` is enabled.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `hledger.keybindings.alignAmount` | `true` | Enable Tab to align amount |
+| `hledger.formatting.alignAmounts` | `true` | Auto-align amounts on format |
+
+## Enter: inline suggestion
+
+Press **Enter** after a payee name to accept the ghost text suggestion and insert a full transaction template.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `hledger.keybindings.enterAndSuggest` | `true` | Enable Enter to accept inline suggestion |
+
+## Status bar hints
+
+When editing an hledger file, the status bar shows a quick reference:
+
+```
+⌘K S: status · Tab: align · Enter: suggest
+```
+
+---
+
+For full details see the [User Guide](../user-guide.md).

--- a/docs/walkthrough/reports.md
+++ b/docs/walkthrough/reports.md
@@ -1,0 +1,55 @@
+# Generate Reports
+
+Run hledger commands directly from VS Code and insert results as comments in your journal.
+
+## Available commands
+
+Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and search for "HLedger":
+
+| Command | Description | hledger command |
+|---------|-------------|-----------------|
+| **HLedger: Insert Balance Sheet** | Assets and liabilities overview | `hledger bs` |
+| **HLedger: Insert Income Statement** | Revenue and expense summary | `hledger incomestatement` |
+| **HLedger: Insert Statistics Report** | File statistics and metrics | `hledger stats` |
+
+## Example output
+
+Reports are inserted as comments at the cursor position:
+
+```hledger
+; hledger bs - 2025-01-15
+; ==================================================
+; Balance Sheet 2025-01-15
+;              ||  2025-01-15
+; =============++=============
+;  Assets      ||
+; -------------++-------------
+;  Assets:Bank || 2450.00 USD
+; ==================================================
+```
+
+## Journal file resolution
+
+The extension determines which journal file to use:
+
+1. **`LEDGER_FILE` environment variable** — if set and valid
+2. **`hledger.cli.journalFile` setting** — if configured
+3. **Current open file** — as fallback
+
+## Prerequisites
+
+- hledger must be installed and in your PATH
+- Or set an explicit path via `hledger.cli.path`
+
+## Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `hledger.cli.enabled` | Enable CLI integration | `true` |
+| `hledger.cli.path` | Path to hledger executable | Auto-detected |
+| `hledger.cli.journalFile` | Main journal file path | Uses env or current file |
+| `hledger.cli.timeout` | Command timeout (ms) | `30000` |
+
+---
+
+For full details see the [User Guide](../user-guide.md).

--- a/package.json
+++ b/package.json
@@ -644,6 +644,31 @@
               "onCommand:hledger.import.fromFile",
               "onCommand:hledger.import.fromSelection"
             ]
+          },
+          {
+            "id": "hledger.reports",
+            "title": "Generate Reports",
+            "description": "Insert balance sheet, income statement, and statistics reports directly into your journal.\n\n[Insert Balance Sheet](command:hledger.cli.balance)",
+            "media": {
+              "markdown": "docs/walkthrough/reports.md"
+            },
+            "completionEvents": [
+              "onCommand:hledger.cli.balance",
+              "onCommand:hledger.cli.incomestatement",
+              "onCommand:hledger.cli.stats"
+            ]
+          },
+          {
+            "id": "hledger.keybindings",
+            "title": "Keyboard Shortcuts",
+            "description": "Use **Cmd+K S** to cycle transaction status, **Tab** to align amounts, and **Enter** to accept inline suggestions.",
+            "media": {
+              "markdown": "docs/walkthrough/keybindings.md"
+            },
+            "completionEvents": [
+              "onCommand:hledger.editor.cycleStatus",
+              "onCommand:hledger.editor.alignAmount"
+            ]
           }
         ]
       }

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -823,6 +823,7 @@ export const window = {
     document: null,
     edit: jest.fn(),
   },
+  onDidChangeActiveTextEditor: jest.fn(() => ({ dispose: jest.fn() })),
   withProgress: jest.fn((options, task) =>
     task(
       { report: jest.fn() },
@@ -847,6 +848,7 @@ export const window = {
     (_alignment?: StatusBarAlignment, _priority?: number) => ({
       text: '',
       tooltip: '',
+      name: undefined as string | undefined,
       command: undefined as string | undefined,
       color: undefined as string | undefined,
       backgroundColor: undefined as any,

--- a/src/extension/KeybindingHintsStatusBar.ts
+++ b/src/extension/KeybindingHintsStatusBar.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+
+const HLEDGER_LANGUAGE_ID = 'hledger';
+
+export class KeybindingHintsStatusBar implements vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      99
+    );
+    this.item.text = '$(keyboard) ⌘K S: status · Tab: align · Enter: suggest';
+    this.item.tooltip = 'HLedger keybindings: Cmd+K S cycles status, Tab aligns amount, Enter accepts suggestion';
+    this.item.name = 'HLedger Keybinding Hints';
+
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        this.updateVisibility(editor);
+      })
+    );
+
+    this.updateVisibility(vscode.window.activeTextEditor);
+  }
+
+  private updateVisibility(editor: vscode.TextEditor | undefined): void {
+    if (editor?.document.languageId === HLEDGER_LANGUAGE_ID) {
+      this.item.show();
+    } else {
+      this.item.hide();
+    }
+  }
+
+  dispose(): void {
+    this.item.dispose();
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+  }
+}

--- a/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
+++ b/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
@@ -1,0 +1,143 @@
+import * as vscode from 'vscode';
+import { KeybindingHintsStatusBar } from '../KeybindingHintsStatusBar';
+
+describe('KeybindingHintsStatusBar', () => {
+  let statusBar: KeybindingHintsStatusBar;
+  let mockItem: any;
+  let editorChangeCallback: ((editor: any) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    editorChangeCallback = undefined;
+
+    (vscode.window as any).activeTextEditor = undefined;
+
+    mockItem = {
+      text: '',
+      tooltip: '',
+      name: undefined as string | undefined,
+      command: undefined as string | undefined,
+      show: jest.fn(),
+      hide: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (vscode.window.createStatusBarItem as jest.Mock).mockReturnValue(mockItem);
+    (vscode.window.onDidChangeActiveTextEditor as jest.Mock).mockImplementation(
+      (callback: (editor: any) => void) => {
+        editorChangeCallback = callback;
+        return { dispose: jest.fn() };
+      }
+    );
+  });
+
+  afterEach(() => {
+    statusBar?.dispose();
+  });
+
+  describe('construction', () => {
+    it('should create status bar item with right alignment and priority 99', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(vscode.window.createStatusBarItem).toHaveBeenCalledWith(
+        vscode.StatusBarAlignment.Right,
+        99
+      );
+    });
+
+    it('should set keybinding hints text', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.text).toContain('status');
+      expect(mockItem.text).toContain('align');
+      expect(mockItem.text).toContain('suggest');
+    });
+
+    it('should set tooltip', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.tooltip).toContain('Cmd+K S');
+      expect(mockItem.tooltip).toContain('Tab');
+      expect(mockItem.tooltip).toContain('Enter');
+    });
+
+    it('should set name', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.name).toBe('HLedger Keybinding Hints');
+    });
+
+    it('should register editor change listener', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(vscode.window.onDidChangeActiveTextEditor).toHaveBeenCalled();
+      expect(editorChangeCallback).toBeDefined();
+    });
+  });
+
+  describe('visibility', () => {
+    it('should show when active editor is hledger file', () => {
+      (vscode.window as any).activeTextEditor = {
+        document: { languageId: 'hledger' },
+      };
+
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.show).toHaveBeenCalled();
+    });
+
+    it('should hide when active editor is not hledger file', () => {
+      (vscode.window as any).activeTextEditor = {
+        document: { languageId: 'typescript' },
+      };
+
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.hide).toHaveBeenCalled();
+    });
+
+    it('should hide when no active editor', () => {
+      (vscode.window as any).activeTextEditor = undefined;
+
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.hide).toHaveBeenCalled();
+    });
+
+    it('should update visibility on editor change', () => {
+      (vscode.window as any).activeTextEditor = undefined;
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.hide).toHaveBeenCalled();
+
+      editorChangeCallback!({
+        document: { languageId: 'hledger' },
+      });
+
+      expect(mockItem.show).toHaveBeenCalled();
+    });
+
+    it('should hide when switching away from hledger file', () => {
+      (vscode.window as any).activeTextEditor = {
+        document: { languageId: 'hledger' },
+      };
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.show).toHaveBeenCalled();
+
+      editorChangeCallback!({
+        document: { languageId: 'markdown' },
+      });
+
+      expect(mockItem.hide).toHaveBeenCalled();
+    });
+  });
+
+  describe('dispose', () => {
+    it('should dispose status bar item and listeners', () => {
+      statusBar = new KeybindingHintsStatusBar();
+      statusBar.dispose();
+
+      expect(mockItem.dispose).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/extension/__tests__/activation.test.ts
+++ b/src/extension/__tests__/activation.test.ts
@@ -11,6 +11,12 @@ jest.mock("../lsp/LSPStatusBar", () => ({
   })),
 }));
 
+jest.mock("../KeybindingHintsStatusBar", () => ({
+  KeybindingHintsStatusBar: jest.fn().mockImplementation(() => ({
+    dispose: jest.fn(),
+  })),
+}));
+
 jest.mock("../lsp", () => ({
   LSPManager: jest.fn().mockImplementation(() => ({
     dispose: jest.fn(),

--- a/src/extension/__tests__/walkthrough.test.ts
+++ b/src/extension/__tests__/walkthrough.test.ts
@@ -1,0 +1,109 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('walkthrough configuration', () => {
+  const packageJsonPath = path.resolve(__dirname, '../../../package.json');
+  let pkg: any;
+
+  beforeAll(() => {
+    pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  });
+
+  const getWalkthrough = () => {
+    const walkthroughs = pkg.contributes?.walkthroughs;
+    expect(walkthroughs).toBeDefined();
+    return walkthroughs[0];
+  };
+
+  it('should have a walkthrough with id hledger.getStarted', () => {
+    const walkthrough = getWalkthrough();
+    expect(walkthrough.id).toBe('hledger.getStarted');
+  });
+
+  it('should have 5 steps in order', () => {
+    const walkthrough = getWalkthrough();
+    const stepIds = walkthrough.steps.map((s: any) => s.id);
+
+    expect(stepIds).toEqual([
+      'hledger.installLSP',
+      'hledger.openJournal',
+      'hledger.importCSV',
+      'hledger.reports',
+      'hledger.keybindings',
+    ]);
+  });
+
+  describe('reports step', () => {
+    const getReportsStep = () => {
+      const walkthrough = getWalkthrough();
+      return walkthrough.steps.find((s: any) => s.id === 'hledger.reports');
+    };
+
+    it('should exist', () => {
+      expect(getReportsStep()).toBeDefined();
+    });
+
+    it('should reference reports.md media', () => {
+      const step = getReportsStep();
+      expect(step.media.markdown).toBe('docs/walkthrough/reports.md');
+    });
+
+    it('should have completion events for all CLI commands', () => {
+      const step = getReportsStep();
+      expect(step.completionEvents).toContain('onCommand:hledger.cli.balance');
+      expect(step.completionEvents).toContain('onCommand:hledger.cli.incomestatement');
+      expect(step.completionEvents).toContain('onCommand:hledger.cli.stats');
+    });
+
+    it('should have a media file that exists', () => {
+      const step = getReportsStep();
+      const mediaPath = path.resolve(__dirname, '../../../', step.media.markdown);
+      expect(fs.existsSync(mediaPath)).toBe(true);
+    });
+  });
+
+  describe('keybindings step', () => {
+    const getKeybindingsStep = () => {
+      const walkthrough = getWalkthrough();
+      return walkthrough.steps.find((s: any) => s.id === 'hledger.keybindings');
+    };
+
+    it('should exist', () => {
+      expect(getKeybindingsStep()).toBeDefined();
+    });
+
+    it('should reference keybindings.md media', () => {
+      const step = getKeybindingsStep();
+      expect(step.media.markdown).toBe('docs/walkthrough/keybindings.md');
+    });
+
+    it('should have completion events for status and align commands', () => {
+      const step = getKeybindingsStep();
+      expect(step.completionEvents).toContain('onCommand:hledger.editor.cycleStatus');
+      expect(step.completionEvents).toContain('onCommand:hledger.editor.alignAmount');
+    });
+
+    it('should have a media file that exists', () => {
+      const step = getKeybindingsStep();
+      const mediaPath = path.resolve(__dirname, '../../../', step.media.markdown);
+      expect(fs.existsSync(mediaPath)).toBe(true);
+    });
+  });
+
+  describe('all steps', () => {
+    it('should have media files that exist for every step', () => {
+      const walkthrough = getWalkthrough();
+      for (const step of walkthrough.steps) {
+        const mediaPath = path.resolve(__dirname, '../../../', step.media.markdown);
+        expect(fs.existsSync(mediaPath)).toBe(true);
+      }
+    });
+
+    it('should have non-empty completionEvents for every step', () => {
+      const walkthrough = getWalkthrough();
+      for (const step of walkthrough.steps) {
+        expect(step.completionEvents.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -9,6 +9,7 @@ import { alignAmount } from "./commands/alignAmount";
 import { enterAndSuggest } from "./commands/enterAndSuggest";
 import { cycleStatus, setStatus } from "./commands/toggleStatus";
 import { InlineCompletionProvider } from "./inline/InlineCompletionProvider";
+import { KeybindingHintsStatusBar } from "./KeybindingHintsStatusBar";
 import { Logger } from "./Logger";
 import { LSPStatusBar } from "./lsp/LSPStatusBar";
 import { formatErrorWithContext } from "./ErrorContext";
@@ -28,6 +29,9 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
       lspManager.onStatusChange((status) => statusBar.update(status))
     );
+
+    const keybindingHints = new KeybindingHintsStatusBar();
+    context.subscriptions.push(keybindingHints);
 
     const startupChecker = new StartupChecker(lspManager, context);
 


### PR DESCRIPTION
Closes #221

## Summary

Expand the onboarding walkthrough and make keybindings discoverable in-editor.

## Changes

### Walkthrough (2 new steps)
- **Generate Reports** — covers CLI commands (balance sheet, income statement, stats), journal file resolution, and settings
- **Keyboard Shortcuts** — covers status cycling (⌘K S/0/1/2), Tab align, Enter suggest

### Keybinding hints status bar
- New `KeybindingHintsStatusBar` shows `⌘K S: status · Tab: align · Enter: suggest` in the status bar
- Visible only when editing hledger files, no configuration needed
- Right-aligned, positioned next to the LSP status indicator

### Tests
- `KeybindingHintsStatusBar.test.ts` — 12 tests (construction, visibility, dispose)
- `walkthrough.test.ts` — 11 tests (step order, media files exist, completionEvents)

### Docs
- `docs/user-guide.md` — added "Status Bar Hints" section under Keyboard Shortcuts
- `README.md` — updated walkthrough description

## Verification

- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm test` — 703 tests, 33 suites ✓