### PR TITLE
fix(editor): clean up status and completion behavior

### DIFF
--- a/src/extension/commands/__tests__/toggleStatus.test.ts
+++ b/src/extension/commands/__tests__/toggleStatus.test.ts
@@ -532,6 +532,11 @@ describe("cycleStatus", () => {
       selection: {
         active: new vscode.Position(line, 0),
       },
+      selections: [
+        {
+          active: new vscode.Position(line, 0),
+        },
+      ],
       edit: editMock,
     };
   }
@@ -602,6 +607,56 @@ describe("cycleStatus", () => {
     );
   });
 
+  it("cycles a status marker at the end of a transaction header", async () => {
+    setupEditor("2024-01-15 !");
+    await cycleStatus();
+    const builder = { replace: jest.fn() };
+    editMock.mock.calls[0][0](builder);
+    expect(builder.replace).toHaveBeenCalledWith(
+      new vscode.Range(0, 11, 0, 12),
+      "* ",
+    );
+  });
+
+  it("cycles each unique selected line in one edit", async () => {
+    editMock = jest.fn().mockImplementation(
+      (callback: (builder: { replace: jest.Mock }) => void) => {
+        const builder = { replace: jest.fn() };
+        callback(builder);
+        return Promise.resolve(true);
+      },
+    );
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: "hledger",
+        lineAt: jest.fn((line: number) => ({
+          text: ["2024-01-15 Grocery Store", "    * assets:checking  $100"][line],
+        })),
+      },
+      selection: { active: new vscode.Position(0, 0) },
+      selections: [
+        { active: new vscode.Position(0, 0) },
+        { active: new vscode.Position(1, 0) },
+        { active: new vscode.Position(0, 5) },
+      ],
+      edit: editMock,
+    };
+
+    await cycleStatus();
+
+    const builder = { replace: jest.fn() };
+    editMock.mock.calls[0][0](builder);
+    expect(builder.replace).toHaveBeenCalledTimes(2);
+    expect(builder.replace).toHaveBeenCalledWith(
+      new vscode.Range(0, 11, 0, 11),
+      "! ",
+    );
+    expect(builder.replace).toHaveBeenCalledWith(
+      new vscode.Range(1, 4, 1, 6),
+      "",
+    );
+  });
+
   it("cycles unmarked posting to pending", async () => {
     setupEditor("    assets:checking  $100", 1);
     await cycleStatus();
@@ -647,6 +702,11 @@ describe("setStatus", () => {
       selection: {
         active: new vscode.Position(line, 0),
       },
+      selections: [
+        {
+          active: new vscode.Position(line, 0),
+        },
+      ],
       edit: editMock,
     };
   }
@@ -705,6 +765,45 @@ describe("setStatus", () => {
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: jest.fn() };
     editMock.mock.calls[0][0](builder);
+    expect(builder.replace).toHaveBeenCalledWith(
+      new vscode.Range(1, 4, 1, 4),
+      "* ",
+    );
+  });
+
+  it("sets status on each unique selected line in one edit", async () => {
+    editMock = jest.fn().mockImplementation(
+      (callback: (builder: { replace: jest.Mock }) => void) => {
+        const builder = { replace: jest.fn() };
+        callback(builder);
+        return Promise.resolve(true);
+      },
+    );
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: "hledger",
+        lineAt: jest.fn((line: number) => ({
+          text: ["2024-01-15 Grocery Store", "    assets:checking  $100"][line],
+        })),
+      },
+      selection: { active: new vscode.Position(0, 0) },
+      selections: [
+        { active: new vscode.Position(0, 0) },
+        { active: new vscode.Position(1, 0) },
+        { active: new vscode.Position(1, 5) },
+      ],
+      edit: editMock,
+    };
+
+    await setStatus("*");
+
+    const builder = { replace: jest.fn() };
+    editMock.mock.calls[0][0](builder);
+    expect(builder.replace).toHaveBeenCalledTimes(2);
+    expect(builder.replace).toHaveBeenCalledWith(
+      new vscode.Range(0, 11, 0, 11),
+      "* ",
+    );
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(1, 4, 1, 4),
       "* ",

--- a/src/extension/commands/alignAmount.ts
+++ b/src/extension/commands/alignAmount.ts
@@ -93,7 +93,7 @@ export async function alignAmount(
     const workspaceEdit = new vscode.WorkspaceEdit();
     for (const edit of edits) {
       workspaceEdit.replace(
-        document.uri as unknown as vscode.Uri,
+        document.uri,
         new vscode.Range(
           edit.range.start.line,
           edit.range.start.character,

--- a/src/extension/commands/toggleStatus.ts
+++ b/src/extension/commands/toggleStatus.ts
@@ -42,7 +42,7 @@ export function parseLineStatus(lineText: string): StatusInfo | undefined {
     const afterWhitespace = headerMatch[0].length;
 
     const restAfterDate = lineText.substring(afterWhitespace);
-    const statusMatch = /^([*!])\s+/.exec(restAfterDate);
+    const statusMatch = /^([*!])(?:\s+|$)/.exec(restAfterDate);
 
     if (statusMatch) {
       return {
@@ -121,17 +121,19 @@ export async function cycleStatus(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
   if (editor?.document.languageId !== "hledger") return;
 
-  const line = editor.selection.active.line;
-  const lineText = editor.document.lineAt(line).text;
-  const info = parseLineStatus(lineText);
-  if (!info) return;
-
-  const newStatus = nextStatus(info.status);
-  const edit = buildStatusEdit(lineText, line, newStatus);
-  if (!edit) return;
+  const edits = [...new Set(editor.selections.map((selection) => selection.active.line))]
+    .map((line) => {
+      const lineText = editor.document.lineAt(line).text;
+      const info = parseLineStatus(lineText);
+      return info ? buildStatusEdit(lineText, line, nextStatus(info.status)) : undefined;
+    })
+    .filter((edit): edit is { range: vscode.Range; newText: string } => edit !== undefined);
+  if (edits.length === 0) return;
 
   await editor.edit((editBuilder) => {
-    editBuilder.replace(edit.range, edit.newText);
+    for (const edit of edits) {
+      editBuilder.replace(edit.range, edit.newText);
+    }
   });
 }
 
@@ -141,12 +143,14 @@ export async function setStatus(
   const editor = vscode.window.activeTextEditor;
   if (editor?.document.languageId !== "hledger") return;
 
-  const line = editor.selection.active.line;
-  const lineText = editor.document.lineAt(line).text;
-  const edit = buildStatusEdit(lineText, line, status);
-  if (!edit) return;
+  const edits = [...new Set(editor.selections.map((selection) => selection.active.line))]
+    .map((line) => buildStatusEdit(editor.document.lineAt(line).text, line, status))
+    .filter((edit): edit is { range: vscode.Range; newText: string } => edit !== undefined);
+  if (edits.length === 0) return;
 
   await editor.edit((editBuilder) => {
-    editBuilder.replace(edit.range, edit.newText);
+    for (const edit of edits) {
+      editBuilder.replace(edit.range, edit.newText);
+    }
   });
 }

--- a/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
+++ b/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
@@ -76,7 +76,7 @@ describe("createClientOptions", () => {
     expect(init.features.semanticTokens).toBe(true);
     expect(init.features.inlineCompletion).toBe(true);
     expect(init.features.codeLens).toBe(false);
-    expect(init.completion.maxResults).toBe(25);
+    expect(init.completion.maxResults).toBe(50);
     expect(init.completion.includeNotes).toBe(true);
     expect(init.diagnostics.balanceTolerance).toBe(1e-10);
     expect(init.formatting.amountAlignmentColumn).toBe(0);

--- a/src/extension/lsp/__tests__/settingsMapper.test.ts
+++ b/src/extension/lsp/__tests__/settingsMapper.test.ts
@@ -23,7 +23,7 @@ describe("mapVSCodeSettingsToLSP", () => {
           codeLens: false,
         },
         completion: {
-          maxResults: 25,
+          maxResults: 50,
           fuzzyMatching: true,
           showCounts: true,
           includeNotes: true,

--- a/src/extension/lsp/settingsMapper.ts
+++ b/src/extension/lsp/settingsMapper.ts
@@ -126,7 +126,7 @@ const DEFAULT_SETTINGS: LSPSettings = {
     codeLens: false,
   },
   completion: {
-    maxResults: 25,
+    maxResults: 50,
     fuzzyMatching: true,
     showCounts: true,
     includeNotes: true,

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -152,22 +152,6 @@ export function activate(context: vscode.ExtensionContext): void {
     );
     context.subscriptions.push(inlineProvider);
 
-    // Register manual completion commands
-    context.subscriptions.push(
-      vscode.commands.registerCommand("hledger.triggerDateCompletion", () => {
-        vscode.commands.executeCommand("editor.action.triggerSuggest");
-      }),
-    );
-
-    context.subscriptions.push(
-      vscode.commands.registerCommand(
-        "hledger.triggerAccountCompletion",
-        () => {
-          vscode.commands.executeCommand("editor.action.triggerSuggest");
-        },
-      ),
-    );
-
     // Create CLI service and commands
     const cliService = new HLedgerCliService();
     const cliCommands = new HLedgerCliCommands(cliService);


### PR DESCRIPTION
## Purpose

Fix the first independent part of #218: make status commands work correctly with multiple cursors and remove minor inconsistencies in the extension code. This PR does not close the umbrella issue; networking and import changes will follow in separate PRs.

## Changes

- Apply status changes to every unique selected line in a single editor transaction.
- Recognize a status marker at the end of a transaction header.
- Align the fallback `maxResults` value with the manifest default of 50.
- Remove unused completion command registrations and an unnecessary URI double cast.

## Verification

- `npm test -- --runInBand` — 33 suites, 706 tests, 1 snapshot.
- `npm run lint`.
- `npm run typecheck`.
- `npm run build`.
- Independent review — approved with no proven S1/S2 defects.

## Code pointers

- `src/extension/commands/toggleStatus.ts` — selection handling and status marker parsing.
- `src/extension/lsp/settingsMapper.ts` — fallback `maxResults` value.
- `src/extension/main.ts` — removed command registrations.
- `src/extension/commands/alignAmount.ts` — direct use of the document URI.

Refs #218
