### PR TITLE
fix(lsp): cancel payee history requests on timeout

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -112,6 +112,44 @@ export interface CancellationToken {
   onCancellationRequested: any;
 }
 
+export class CancellationTokenSource {
+  private isCancelled = false;
+  private isDisposed = false;
+  private readonly listeners = new Set<() => void>();
+  readonly token: CancellationToken;
+
+  constructor() {
+    const source = this;
+    this.token = {
+      get isCancellationRequested(): boolean {
+        return source.isCancelled;
+      },
+      onCancellationRequested: (listener: () => void) => {
+        source.listeners.add(listener);
+        return {
+          dispose: () => source.listeners.delete(listener),
+        };
+      },
+    };
+  }
+
+  cancel(): void {
+    if (this.isCancelled || this.isDisposed) {
+      return;
+    }
+
+    this.isCancelled = true;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  dispose(): void {
+    this.isDisposed = true;
+    this.listeners.clear();
+  }
+}
+
 export class CompletionItem {
   label: string;
   kind?: CompletionItemKind;

--- a/src/extension/lsp/HLedgerLanguageClient.ts
+++ b/src/extension/lsp/HLedgerLanguageClient.ts
@@ -238,23 +238,23 @@ export class HLedgerLanguageClient implements vscode.Disposable {
     }
 
     const timeout = 5000;
+    const cancellationTokenSource = new vscode.CancellationTokenSource();
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<null>((resolve) => {
-      timeoutId = setTimeout(() => resolve(null), timeout);
+      timeoutId = setTimeout(() => {
+        resolve(null);
+        cancellationTokenSource.cancel();
+      }, timeout);
     });
 
     try {
       const requestPromise = this.client.sendRequest<PayeeAccountHistoryResult>(
         'hledger/payeeAccountHistory',
-        { textDocument: { uri } }
+        { textDocument: { uri } },
+        cancellationTokenSource.token
       );
 
       const result = await Promise.race([requestPromise, timeoutPromise]);
-
-      // Clear timeout immediately after race completes
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
 
       // Validate response schema
       if (result !== null && !isValidPayeeAccountHistory(result)) {
@@ -264,12 +264,13 @@ export class HLedgerLanguageClient implements vscode.Disposable {
 
       return result;
     } catch (error) {
-      // Clear timeout on error
+      console.error('LSP payee account history request failed:', error);
+      return null;
+    } finally {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
       }
-      console.error('LSP payee account history request failed:', error);
-      return null;
+      cancellationTokenSource.dispose();
     }
   }
 

--- a/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
+++ b/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as vscode from "vscode";
 import {
   HLedgerLanguageClient,
   LanguageClientState,
@@ -230,63 +231,76 @@ describe("HLedgerLanguageClient", () => {
       expect(result).toBeNull();
     });
 
-    it("returns null when sendRequest throws", async () => {
+    it("passes a cancellation token and disposes it after a successful request", async () => {
       const client = new HLedgerLanguageClient(binaryPath);
       await client.start();
 
-      // Mock sendRequest to throw
       const internalClient = client.getClient();
-      jest.spyOn(internalClient!, "sendRequest").mockRejectedValue(new Error("Network error"));
-
-      const result = await client.getPayeeAccountHistory("file:///test.journal");
-      expect(result).toBeNull();
-
-      client.dispose();
-    });
-
-    it("returns result on success", async () => {
-      const client = new HLedgerLanguageClient(binaryPath);
-      await client.start();
-
       const mockResult = {
         payeeAccounts: { "Store": ["Expenses:Food"] },
-        pairUsage: { "Store::Expenses:Food": 5 }
+        pairUsage: { "Store::Expenses:Food": 5 },
       };
-
-      const internalClient = client.getClient();
-      jest.spyOn(internalClient!, "sendRequest").mockResolvedValue(mockResult);
+      const sendRequestSpy = jest.spyOn(internalClient!, "sendRequest").mockResolvedValue(mockResult);
+      const cancelSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "cancel");
+      const disposeSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "dispose");
 
       const result = await client.getPayeeAccountHistory("file:///test.journal");
       expect(result).toEqual(mockResult);
+      expect(sendRequestSpy).toHaveBeenCalledWith(
+        "hledger/payeeAccountHistory",
+        { textDocument: { uri: "file:///test.journal" } },
+        expect.objectContaining({ isCancellationRequested: false })
+      );
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
 
       client.dispose();
     });
 
-    it("returns null when request times out and clears timer", async () => {
+    it("disposes the cancellation token without cancelling when sendRequest rejects", async () => {
       const client = new HLedgerLanguageClient(binaryPath);
       await client.start();
 
-      // Mock request that never resolves
+      const internalClient = client.getClient();
+      jest.spyOn(internalClient!, "sendRequest").mockRejectedValue(new Error("Network error"));
+      const cancelSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "cancel");
+      const disposeSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "dispose");
+
+      const result = await client.getPayeeAccountHistory("file:///test.journal");
+      expect(result).toBeNull();
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+
+      client.dispose();
+    });
+
+    it("cancels at the 5000ms timeout after resolving null and disposes the token", async () => {
+      const client = new HLedgerLanguageClient(binaryPath);
+      await client.start();
+
       const internalClient = client.getClient();
       jest.spyOn(internalClient!, "sendRequest").mockImplementation(
-        () => new Promise(() => {}) // Never resolves
+        (_method, _params, token) => new Promise((_resolve, reject) => {
+          token?.onCancellationRequested(() => reject(new Error("Request cancelled")));
+        })
       );
 
       jest.useFakeTimers();
-      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const cancelSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "cancel");
+      const disposeSpy = jest.spyOn(vscode.CancellationTokenSource.prototype, "dispose");
 
       const resultPromise = client.getPayeeAccountHistory("file:///test.journal");
 
-      // Advance time past 5000ms timeout
-      jest.advanceTimersByTime(5001);
+      jest.advanceTimersByTime(4999);
+      expect(cancelSpy).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
 
       const result = await resultPromise;
       expect(result).toBeNull();
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
 
-      // Verify timer was cleaned up
-      expect(clearTimeoutSpy).toHaveBeenCalled();
-
-      clearTimeoutSpy.mockRestore();
       jest.useRealTimers();
       client.dispose();
     });

--- a/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
+++ b/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
@@ -280,7 +280,7 @@ describe("HLedgerLanguageClient", () => {
 
       const internalClient = client.getClient();
       jest.spyOn(internalClient!, "sendRequest").mockImplementation(
-        (_method, _params, token) => new Promise((_resolve, reject) => {
+        (_method: string, _params: unknown, token?: vscode.CancellationToken) => new Promise((_resolve, reject) => {
           token?.onCancellationRequested(() => reject(new Error("Request cancelled")));
         })
       );


### PR DESCRIPTION
## Purpose

Cancel timed-out payee history requests instead of leaving them running in the language server. This is an independent part of #218; proxy and import changes will follow separately.

## Changes

- Pass a request-local `CancellationToken` to `hledger/payeeAccountHistory`.
- Cancel the token when the existing five-second timeout expires.
- Dispose the token source and clear the timer on every completion path.
- Extend the VS Code test mock with observable cancellation behavior.

## Verification

- TDD RED: 3 new lifecycle tests failed before the production change.
- Targeted Jest: 22 tests passed.
- Full Jest: 33 suites, 703 tests, 1 snapshot passed.
- `npm run lint`.
- `npm run typecheck`.
- `npm run build`.
- Independent review — approved with no proven S1/S2 defects.

## Code pointers

- `src/extension/lsp/HLedgerLanguageClient.ts` — timeout and cancellation lifecycle.
- `src/__mocks__/vscode.ts` — test `CancellationTokenSource`.
- `src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts` — success, error, and timeout coverage.

Refs #218
