### PR TITLE
fix(lsp): support proxy-aware binary downloads

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -300,6 +300,8 @@ The Language Server is auto-installed on first activation. If it is not installe
    - Extract to a permanent location
    - Set in settings: `"hledger.lsp.path": "/path/to/hledger-lsp"`
 
+4. **Corporate proxy:** Set VS Code's `http.proxy` to use that proxy for both HTTP and HTTPS Language Server downloads. If `http.proxy` is empty, downloads use `HTTP_PROXY` and `HTTPS_PROXY`; `NO_PROXY` still bypasses the proxy for matching hosts. Reload VS Code after changing proxy settings. Manual installation remains available if the network policy requires a proxy method the extension does not support.
+
 ### GitHub Rate Limit Errors
 
 **Symptoms:** "GitHub API rate limit exceeded" when installing/updating

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -876,6 +876,8 @@ The Language Server is required and auto-installed on first activation. If the L
 
 The Language Server is automatically installed on first activation. If prompted, accept the installation to enable all features. The binary is stored in VS Code's global storage directory.
 
+If downloads require a proxy, set VS Code's `http.proxy`. Its non-empty value is used for both HTTP and HTTPS release downloads. When `http.proxy` is empty, the extension uses `HTTP_PROXY` and `HTTPS_PROXY` from the environment; `NO_PROXY` still bypasses the proxy for matching hosts. Reload VS Code after changing proxy settings so the Language Server download transport is recreated.
+
 A **Get Started** walkthrough is available via Command Palette → **HLedger: Get Started**. It guides you through Language Server installation, opening a journal file, and importing from CSV.
 
 To manually reinstall or update:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "undici": "^6.27.0",
         "vscode-languageclient": "^10.1.0"
       },
       "devDependencies": {
@@ -4106,6 +4107,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/chownr": {
@@ -9463,13 +9474,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -725,6 +725,7 @@
   "homepage": "https://github.com/juev/hledger-vscode#readme",
   "icon": "images/icon.png",
   "dependencies": {
+    "undici": "^6.27.0",
     "vscode-languageclient": "^10.1.0"
   }
 }

--- a/src/extension/lsp/BinaryManager.ts
+++ b/src/extension/lsp/BinaryManager.ts
@@ -2,6 +2,12 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import * as vscode from "vscode";
+import {
+  EnvHttpProxyAgent,
+  fetch as undiciFetch,
+  type RequestInit as UndiciRequestInit,
+} from "undici";
 import { verify as verifyMinisign } from "./minisignVerify";
 import { MINISIGN_PUBLIC_KEY } from "./signingKey";
 
@@ -34,6 +40,27 @@ export interface ReleaseInfo {
 }
 
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+interface FetchRequestInit {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+interface FetchReader {
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  cancel(): Promise<void>;
+}
+
+interface FetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(name: string): string | null };
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  body: { getReader(): FetchReader } | null;
+}
 
 interface GitHubReleaseResponse {
   tag_name: string;
@@ -122,24 +149,66 @@ export function getBinaryName(platform: string): string {
 
 export class BinaryManager {
   private readonly storageDir: string;
-  private readonly fetchFn: FetchFn;
+  private readonly injectedFetchFn: FetchFn | undefined;
   private readonly platformInfo: PlatformInfo;
+  private dispatcher: EnvHttpProxyAgent | undefined;
+  private disposed = false;
 
   constructor(storageDir: string, fetchFn?: FetchFn, platformInfo?: PlatformInfo) {
     this.storageDir = storageDir;
-    this.fetchFn = fetchFn ?? fetch;
+    this.injectedFetchFn = fetchFn;
     this.platformInfo = platformInfo ?? getPlatformInfo(os.platform(), os.arch());
+  }
+
+  private async fetchDefault(
+    url: string,
+    init: FetchRequestInit,
+  ): Promise<FetchResponse> {
+    if (this.disposed) {
+      throw new NonRetryableError("BinaryManager has been disposed");
+    }
+
+    if (!this.dispatcher) {
+      const proxy = vscode.workspace.getConfiguration("http").get<string>("proxy")?.trim();
+      this.dispatcher = proxy
+        ? new EnvHttpProxyAgent({ httpProxy: proxy, httpsProxy: proxy })
+        : new EnvHttpProxyAgent();
+    }
+
+    const dispatcher = this.dispatcher;
+    const requestInit: UndiciRequestInit = { ...init, dispatcher };
+    return undiciFetch(url, requestInit);
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
+    const dispatcher = this.dispatcher;
+    this.dispatcher = undefined;
+    if (dispatcher) {
+      dispatcher.destroy().catch(() => {});
+    }
   }
 
   private async fetchWithTimeout(
     url: string,
-    init?: RequestInit,
+    init?: FetchRequestInit,
     timeoutMs: number = API_TIMEOUT_MS,
-  ): Promise<Response> {
+  ): Promise<FetchResponse> {
+    if (this.disposed) {
+      throw new NonRetryableError("BinaryManager has been disposed");
+    }
+
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const response = await this.fetchFn(url, { ...init, signal: controller.signal });
+      const requestInit = { ...init, signal: controller.signal };
+      const response = this.injectedFetchFn
+        ? await this.injectedFetchFn(url, requestInit)
+        : await this.fetchDefault(url, requestInit);
       return response;
     } catch (error: unknown) {
       if (error instanceof Error && error.name === "AbortError") {
@@ -173,9 +242,9 @@ export class BinaryManager {
 
   private fetchWithRetry(
     url: string,
-    init?: RequestInit,
+    init?: FetchRequestInit,
     timeoutMs: number = API_TIMEOUT_MS,
-  ): Promise<Response> {
+  ): Promise<FetchResponse> {
     return this.withRetry(() => this.fetchWithTimeout(url, init, timeoutMs));
   }
 

--- a/src/extension/lsp/LSPManager.ts
+++ b/src/extension/lsp/LSPManager.ts
@@ -187,6 +187,7 @@ export class LSPManager implements vscode.Disposable {
   }
 
   dispose(): void {
+    this.binaryManager.dispose();
     if (this.client !== null) {
       this.client.dispose();
       this.client = null;

--- a/src/extension/lsp/__tests__/BinaryManager.test.ts
+++ b/src/extension/lsp/__tests__/BinaryManager.test.ts
@@ -11,6 +11,19 @@ import {
 } from "../BinaryManager";
 import { verify as verifyMinisign } from "../minisignVerify";
 
+jest.mock("undici", () => ({
+  fetch: jest.fn(),
+  EnvHttpProxyAgent: jest.fn(),
+}));
+
+interface UndiciMock {
+  fetch: jest.Mock;
+  EnvHttpProxyAgent: jest.Mock;
+}
+
+const { fetch: mockUndiciFetch, EnvHttpProxyAgent: mockEnvHttpProxyAgent } =
+  jest.requireMock<UndiciMock>("undici");
+
 jest.mock("../minisignVerify", () => ({
   verify: jest.fn(),
 }));
@@ -224,6 +237,166 @@ describe("BinaryManager", () => {
   });
 
   describe("getLatestRelease", () => {
+    it("creates a local proxy dispatcher lazily and caches it for default requests", async () => {
+      const vscode = require("vscode");
+      const originalGetConfiguration = vscode.workspace.getConfiguration;
+      const dispatcher = { destroy: jest.fn().mockResolvedValue(undefined) };
+      const releaseResponse = {
+        ok: true,
+        json: () => Promise.resolve({ tag_name: "v0.2.0", assets: [] }),
+      };
+      const configuration = { get: jest.fn().mockReturnValue("  http://proxy.example:8080  ") };
+
+      vscode.workspace.getConfiguration = jest.fn().mockReturnValue(configuration);
+      mockEnvHttpProxyAgent.mockReturnValue(dispatcher);
+      mockUndiciFetch.mockResolvedValue(releaseResponse);
+
+      try {
+        manager = new BinaryManager(tempDir);
+
+        expect(vscode.workspace.getConfiguration).not.toHaveBeenCalled();
+        expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+
+        await manager.getLatestRelease();
+        await manager.getLatestRelease();
+
+        expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith("http");
+        expect(configuration.get).toHaveBeenCalledWith("proxy");
+        expect(mockEnvHttpProxyAgent).toHaveBeenCalledTimes(1);
+        expect(mockEnvHttpProxyAgent).toHaveBeenCalledWith({
+          httpProxy: "http://proxy.example:8080",
+          httpsProxy: "http://proxy.example:8080",
+        });
+        expect(mockUndiciFetch).toHaveBeenCalledTimes(2);
+        expect(mockUndiciFetch.mock.calls[0]?.[1]).toEqual(
+          expect.objectContaining({ dispatcher, signal: expect.any(AbortSignal) }),
+        );
+        expect(mockUndiciFetch.mock.calls[1]?.[1]).toEqual(
+          expect.objectContaining({ dispatcher, signal: expect.any(AbortSignal) }),
+        );
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+      }
+    });
+
+    it("uses environment proxy settings when http.proxy is blank", async () => {
+      const vscode = require("vscode");
+      const originalGetConfiguration = vscode.workspace.getConfiguration;
+      const dispatcher = { destroy: jest.fn().mockResolvedValue(undefined) };
+
+      vscode.workspace.getConfiguration = jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue("   "),
+      });
+      mockEnvHttpProxyAgent.mockReturnValue(dispatcher);
+      mockUndiciFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ tag_name: "v0.2.0", assets: [] }),
+      });
+
+      try {
+        manager = new BinaryManager(tempDir);
+
+        await manager.getLatestRelease();
+
+        expect(mockEnvHttpProxyAgent).toHaveBeenCalledWith();
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+      }
+    });
+
+    it("keeps injected fetch independent from proxy configuration", async () => {
+      const vscode = require("vscode");
+      const originalGetConfiguration = vscode.workspace.getConfiguration;
+      const injectedFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ tag_name: "v0.2.0", assets: [] }),
+      });
+
+      vscode.workspace.getConfiguration = jest.fn();
+
+      try {
+        manager = new BinaryManager(tempDir, injectedFetch);
+
+        await manager.getLatestRelease();
+
+        expect(injectedFetch).toHaveBeenCalledTimes(1);
+        expect(vscode.workspace.getConfiguration).not.toHaveBeenCalled();
+        expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+      }
+    });
+
+    it("rejects network use after disposal before proxy or fetch side effects", async () => {
+      const vscode = require("vscode");
+      const originalGetConfiguration = vscode.workspace.getConfiguration;
+      const injectedFetch = jest.fn();
+
+      vscode.workspace.getConfiguration = jest.fn();
+
+      try {
+        manager = new BinaryManager(tempDir, injectedFetch);
+        manager.dispose();
+
+        await expect(manager.getLatestRelease()).rejects.toThrow("disposed");
+
+        expect(vscode.workspace.getConfiguration).not.toHaveBeenCalled();
+        expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+        expect(injectedFetch).not.toHaveBeenCalled();
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+      }
+    });
+
+    it("rejects default network use after disposal before proxy side effects", async () => {
+      const vscode = require("vscode");
+      const originalGetConfiguration = vscode.workspace.getConfiguration;
+
+      vscode.workspace.getConfiguration = jest.fn();
+
+      try {
+        manager = new BinaryManager(tempDir);
+        manager.dispose();
+
+        await expect(manager.getLatestRelease()).rejects.toThrow("disposed");
+
+        expect(vscode.workspace.getConfiguration).not.toHaveBeenCalled();
+        expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+        expect(mockUndiciFetch).not.toHaveBeenCalled();
+      } finally {
+        vscode.workspace.getConfiguration = originalGetConfiguration;
+      }
+    });
+
+    it("sets disposal state before destroying the cached dispatcher and destroys it once", async () => {
+      let requestDuringDestroy: Promise<ReleaseInfo> | undefined;
+      const dispatcher = {
+        destroy: jest.fn().mockImplementation(() => {
+          requestDuringDestroy = manager.getLatestRelease();
+          return Promise.reject(new Error("destroy failed"));
+        }),
+      };
+      mockEnvHttpProxyAgent.mockReturnValue(dispatcher);
+      mockUndiciFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ tag_name: "v0.2.0", assets: [] }),
+      });
+
+      manager = new BinaryManager(tempDir);
+      await manager.getLatestRelease();
+      mockEnvHttpProxyAgent.mockClear();
+      mockUndiciFetch.mockClear();
+
+      manager.dispose();
+      manager.dispose();
+      await Promise.resolve();
+
+      expect(dispatcher.destroy).toHaveBeenCalledTimes(1);
+      await expect(requestDuringDestroy).rejects.toThrow("disposed");
+      expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+      expect(mockUndiciFetch).not.toHaveBeenCalled();
+    });
+
     it("fetches release info from GitHub API", async () => {
       const mockFetch = jest.fn().mockResolvedValue({
         ok: true,

--- a/src/extension/lsp/__tests__/LSPManager.test.ts
+++ b/src/extension/lsp/__tests__/LSPManager.test.ts
@@ -1,7 +1,29 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { BinaryManager } from "../BinaryManager";
 import { LSPManager, LSPStatus } from "../LSPManager";
+
+jest.mock("undici", () => ({
+  fetch: jest.fn(),
+  EnvHttpProxyAgent: jest.fn(),
+}));
+
+interface UndiciMock {
+  fetch: jest.Mock;
+  EnvHttpProxyAgent: jest.Mock;
+}
+
+const { fetch: mockUndiciFetch, EnvHttpProxyAgent: mockEnvHttpProxyAgent } =
+  jest.requireMock<UndiciMock>("undici");
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 describe("LSPManager", () => {
   let tempDir: string;
@@ -31,6 +53,16 @@ describe("LSPManager", () => {
       const manager = new LSPManager(mockContext);
 
       expect(manager.getStatus()).toBe(LSPStatus.NotInstalled);
+    });
+
+    it("does not read proxy configuration while activating", () => {
+      const vscode = require("vscode");
+      vscode.workspace.getConfiguration = jest.fn();
+
+      new LSPManager(mockContext);
+
+      expect(vscode.workspace.getConfiguration).not.toHaveBeenCalledWith("http");
+      expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
     });
   });
 
@@ -89,6 +121,37 @@ describe("LSPManager", () => {
       const manager = new LSPManager(mockContext);
 
       expect(() => manager.dispose()).not.toThrow();
+    });
+
+    it("always disposes the binary manager", () => {
+      const dispose = jest.spyOn(BinaryManager.prototype, "dispose");
+      const manager = new LSPManager(mockContext);
+
+      manager.dispose();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects a deferred update check after deactivate without proxy resurrection", async () => {
+      const vscode = require("vscode");
+      const version = createDeferred<string | null>();
+      const getInstalledVersion = jest
+        .spyOn(BinaryManager.prototype, "getInstalledVersion")
+        .mockReturnValue(version.promise);
+
+      vscode.workspace.getConfiguration = jest.fn();
+      const manager = new LSPManager(mockContext);
+      const updateCheck = manager.checkForUpdates();
+
+      manager.dispose();
+      version.resolve(null);
+
+      await expect(updateCheck).rejects.toThrow("disposed");
+      expect(vscode.workspace.getConfiguration).not.toHaveBeenCalledWith("http");
+      expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+      expect(mockUndiciFetch).not.toHaveBeenCalled();
+
+      getInstalledVersion.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Purpose

Allow automatic Language Server installation and updates to work behind HTTP proxies. This is an independent part of #218; the remaining import and formatting changes will follow separately.

## Changes

- Route the default binary download path through a local `EnvHttpProxyAgent` from `undici@6.27.0`.
- Use a non-empty VS Code `http.proxy` value for both HTTP and HTTPS, otherwise preserve the standard proxy environment and `NO_PROXY` behavior.
- Create and cache the dispatcher only on the first network request, leaving extension activation and injected test transports untouched.
- Make `BinaryManager.dispose()` monotonic and prevent deferred update checks from recreating network resources after deactivation.
- Destroy the owned dispatcher through `LSPManager.dispose()` and document proxy precedence and reload behavior.

## Verification

- TDD RED reproduced the missing proxy configuration lookup.
- Targeted Jest: 2 suites, 73 tests passed.
- Full Jest: 33 suites, 715 tests, 1 snapshot passed.
- `npm run lint`.
- `npm run typecheck`.
- `npm run compile`.
- `npm run build`.
- `npx vsce package`.
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
- Independent review — approved with no proven S1/S2 defects.

## Code pointers

- `src/extension/lsp/BinaryManager.ts` — proxy transport and dispatcher lifecycle.
- `src/extension/lsp/LSPManager.ts` — disposal ownership.
- `src/extension/lsp/__tests__/BinaryManager.test.ts` — proxy precedence and lifecycle tests.
- `src/extension/lsp/__tests__/LSPManager.test.ts` — activation and deferred deactivation race tests.
- `docs/user-guide.md` and `TROUBLESHOOTING.md` — user-facing proxy contract.

Refs #218
