### PR TITLE
fix(import): preserve CSV records and exact amounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "decimal.js": "^10.6.0",
+        "string-width": "^4.2.3",
         "undici": "^6.27.0",
         "vscode-languageclient": "^10.1.0"
       },
@@ -3549,7 +3551,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4312,6 +4313,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -6044,7 +6051,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8832,7 +8838,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8870,14 +8875,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -725,6 +725,8 @@
   "homepage": "https://github.com/juev/hledger-vscode#readme",
   "icon": "images/icon.png",
   "dependencies": {
+    "decimal.js": "^10.6.0",
+    "string-width": "^4.2.3",
     "undici": "^6.27.0",
     "vscode-languageclient": "^10.1.0"
   }

--- a/src/extension/import/AccountResolver.ts
+++ b/src/extension/import/AccountResolver.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode';
+import Decimal from 'decimal.js';
 import {
     AccountResolution,
     AccountResolutionSource,
@@ -157,7 +158,7 @@ export class AccountResolver {
     resolve(
         description: string,
         category?: string,
-        amount?: number
+        amount?: Decimal | number
     ): AccountResolution {
         // Strategy 1: Journal history (highest priority)
         if (this.useHistory && description) {
@@ -402,14 +403,21 @@ export class AccountResolver {
     /**
      * Resolve account from amount sign
      */
-    private resolveFromAmount(amount: number): AccountResolution {
-        if (amount > 0) {
+    private resolveFromAmount(amount: Decimal | number): AccountResolution {
+        const isPositive = typeof amount === 'number'
+            ? amount > 0
+            : !amount.isZero() && amount.isPositive();
+        const isNegative = typeof amount === 'number'
+            ? amount < 0
+            : !amount.isZero() && amount.isNegative();
+
+        if (isPositive) {
             return {
                 account: this.defaultCreditAccount,
                 confidence: CONFIDENCE.AMOUNT_SIGN,
                 source: 'sign',
             };
-        } else if (amount < 0) {
+        } else if (isNegative) {
             return {
                 account: this.defaultDebitAccount,
                 confidence: CONFIDENCE.AMOUNT_SIGN,

--- a/src/extension/import/TabularDataParser.ts
+++ b/src/extension/import/TabularDataParser.ts
@@ -50,14 +50,7 @@ export class TabularDataParser {
 
         // Normalize line endings
         const normalizedContent = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-        const lines = normalizedContent.split('\n');
-
-        // Track original line numbers before filtering
-        // Each entry is { line: string, originalLineNumber: number }
-        const linesWithNumbers = lines.map((line, index) => ({
-            line,
-            originalLineNumber: index + 1,
-        }));
+        const linesWithNumbers = this.splitLogicalRecords(normalizedContent);
 
         // Filter empty lines if configured, preserving original line numbers
         const nonEmptyLinesWithNumbers = this.options.skipEmptyRows
@@ -68,7 +61,7 @@ export class TabularDataParser {
             return failure('No data lines found');
         }
 
-        // Extract just the lines for delimiter detection
+        // Extract just the logical records for delimiter detection
         const nonEmptyLines = nonEmptyLinesWithNumbers.map((entry) => entry.line);
 
         // Detect delimiter if not specified
@@ -121,7 +114,7 @@ export class TabularDataParser {
 
     /**
      * Auto-detect delimiter from content
-     * Analyzes first 10 lines to determine most likely delimiter
+     * Analyzes first 10 logical records to determine most likely delimiter
      */
     detectDelimiter(lines: string[]): Delimiter | null {
         const delimiters: Delimiter[] = [',', '\t', ';', '|'];
@@ -204,6 +197,46 @@ export class TabularDataParser {
         }
 
         return count;
+    }
+
+    /**
+     * Split content into RFC 4180 logical records while preserving each record's
+     * starting physical line number.
+     */
+    private splitLogicalRecords(content: string): Array<{ line: string; originalLineNumber: number }> {
+        const records: Array<{ line: string; originalLineNumber: number }> = [];
+        let line = '';
+        let inQuotes = false;
+        let physicalLineNumber = 1;
+        let recordStartLineNumber = 1;
+
+        for (let i = 0; i < content.length; i++) {
+            const char = content[i];
+
+            if (char === '"') {
+                line += char;
+                if (inQuotes && i + 1 < content.length && content[i + 1] === '"') {
+                    line += '"';
+                    i++;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (char === '\n') {
+                physicalLineNumber++;
+                if (inQuotes) {
+                    line += char;
+                } else {
+                    records.push({ line, originalLineNumber: recordStartLineNumber });
+                    line = '';
+                    recordStartLineNumber = physicalLineNumber;
+                }
+            } else {
+                line += char;
+            }
+        }
+
+        records.push({ line, originalLineNumber: recordStartLineNumber });
+        return records;
     }
 
     /**

--- a/src/extension/import/TransactionGenerator.ts
+++ b/src/extension/import/TransactionGenerator.ts
@@ -17,9 +17,14 @@ import {
     PayeeAccountHistory,
     DEFAULT_IMPORT_OPTIONS,
 } from './types';
+import Decimal from 'decimal.js';
+import stringWidth from 'string-width';
 import { DateParser } from './DateParser';
 import { AccountResolver } from './AccountResolver';
 import { ColumnDetector } from './ColumnDetector';
+
+const MAX_AMOUNT_INPUT_LENGTH = 100;
+const DecimalAmount = Decimal.clone({ precision: 2 * MAX_AMOUNT_INPUT_LENGTH + 2 });
 
 /**
  * Generator for hledger transactions from tabular data
@@ -281,7 +286,7 @@ export class TransactionGenerator {
     private extractAmount(
         row: ParsedRow,
         mappings: readonly ColumnMapping[]
-    ): { success: true; amount: number } | { success: false; error: string } {
+    ): { success: true; amount: Decimal } | { success: false; error: string } {
         // Try single amount column
         const amountMapping = ColumnDetector.findMapping(mappings, 'amount');
         if (amountMapping) {
@@ -289,7 +294,7 @@ export class TransactionGenerator {
             if (amountStr) {
                 const parsed = this.parseAmountString(amountStr);
                 if (parsed !== null) {
-                    const amount = this.options.invertAmounts ? -parsed : parsed;
+                    const amount = this.options.invertAmounts ? parsed.negated() : parsed;
                     return { success: true, amount };
                 }
                 return { success: false, error: `Invalid amount: ${amountStr}` };
@@ -301,15 +306,16 @@ export class TransactionGenerator {
         const creditMapping = ColumnDetector.findMapping(mappings, 'credit');
 
         if (debitMapping || creditMapping) {
-            let amount = 0;
+            let amount = new DecimalAmount(0);
 
             if (debitMapping) {
                 const debitStr = this.getCellValue(row, debitMapping.index);
                 if (debitStr) {
                     const parsed = this.parseAmountString(debitStr);
-                    if (parsed !== null) {
-                        amount -= Math.abs(parsed); // Debits are negative
+                    if (parsed === null) {
+                        return { success: false, error: `Invalid amount: ${debitStr}` };
                     }
+                    amount = amount.minus(parsed.abs()); // Debits are negative
                 }
             }
 
@@ -317,14 +323,15 @@ export class TransactionGenerator {
                 const creditStr = this.getCellValue(row, creditMapping.index);
                 if (creditStr) {
                     const parsed = this.parseAmountString(creditStr);
-                    if (parsed !== null) {
-                        amount += Math.abs(parsed); // Credits are positive
+                    if (parsed === null) {
+                        return { success: false, error: `Invalid amount: ${creditStr}` };
                     }
+                    amount = amount.plus(parsed.abs()); // Credits are positive
                 }
             }
 
-            if (amount !== 0) {
-                const finalAmount = this.options.invertAmounts ? -amount : amount;
+            if (!amount.isZero()) {
+                const finalAmount = this.options.invertAmounts ? amount.negated() : amount;
                 return { success: true, amount: finalAmount };
             }
         }
@@ -408,7 +415,7 @@ export class TransactionGenerator {
      * 5. Applies explicit signs (`+`/`-`) and accounting notation signs
      *
      * @param {string} amountStr - The amount string to parse (e.g., `$1,234.56`, `1.234,56`, `(100)`)
-     * @returns {number | null} The parsed numeric value, or null if parsing fails. Returns null for:
+     * @returns {Decimal | null} The parsed numeric value, or null if parsing fails. Returns null for:
      *   - Strings longer than 100 characters (DoS protection)
      *   - Malformed amounts that cannot be parsed as valid numbers
      *   - Empty strings or strings containing only non-numeric characters
@@ -426,9 +433,9 @@ export class TransactionGenerator {
      * @security No nested loops or backtracking, safe from algorithmic complexity attacks.
      *           DoS protection: rejects strings > 100 characters.
      */
-    private parseAmountString(amountStr: string): number | null {
+    private parseAmountString(amountStr: string): Decimal | null {
         // DoS protection: reject strings over 100 characters
-        if (amountStr.length > 100) {
+        if (amountStr.length > MAX_AMOUNT_INPUT_LENGTH) {
             return null;
         }
 
@@ -441,13 +448,12 @@ export class TransactionGenerator {
         const unsigned = hasSign ? withoutParens.slice(1) : withoutParens;
 
         const normalized = this.normalizeDecimalSeparator(unsigned);
-        const numericValue = parseFloat(normalized);
-
-        if (isNaN(numericValue)) {
+        if (!/^(?:\d+(?:\.\d*)?|\.\d+)$/.test(normalized)) {
             return null;
         }
 
-        return (isNegative ? -1 : 1) * sign * numericValue;
+        const numericValue = new DecimalAmount(normalized);
+        return isNegative !== (sign < 0) ? numericValue.negated() : numericValue;
     }
 
     /**
@@ -535,12 +541,11 @@ export class TransactionGenerator {
     /**
      * Format amount with currency
      */
-    private formatAmount(amount: number, currency?: string): string {
-        const absAmount = Math.abs(amount);
-        const sign = amount < 0 ? '-' : '';
+    private formatAmount(amount: Decimal, currency?: string): string {
+        const absAmount = amount.abs();
+        const sign = amount.isNegative() ? '-' : '';
 
-        // Format with 2 decimal places
-        const formatted = absAmount.toFixed(2);
+        const formatted = absAmount.toFixed(Math.max(2, absAmount.decimalPlaces() ?? 0));
 
         if (currency) {
             // Check if currency is a symbol or code
@@ -622,7 +627,7 @@ export class TransactionGenerator {
 
         // Calculate padding for alignment
         const accountPart = `    ${tx.sourceAccount.account}`;
-        const padding = Math.max(4, 52 - accountPart.length - tx.amountFormatted.length);
+        const padding = Math.max(4, 52 - stringWidth(accountPart) - stringWidth(tx.amountFormatted));
         const amountPadding = ' '.repeat(padding);
 
         if (includeAnnotations && tx.sourceAccount.source !== 'default') {

--- a/src/extension/import/__tests__/AccountResolver.test.ts
+++ b/src/extension/import/__tests__/AccountResolver.test.ts
@@ -1,5 +1,6 @@
 import { AccountResolver } from '../AccountResolver';
 import { DEFAULT_IMPORT_OPTIONS } from '../types';
+import Decimal from 'decimal.js';
 
 describe('AccountResolver', () => {
     let resolver: AccountResolver;
@@ -116,6 +117,13 @@ describe('AccountResolver', () => {
 
         it('should use default placeholder for zero amount', () => {
             const result = resolver.resolve('Unknown Merchant', undefined, 0);
+
+            expect(result.account).toBe('TODO:account');
+            expect(result.source).toBe('default');
+        });
+
+        it('should use default placeholder for a Decimal zero amount', () => {
+            const result = resolver.resolve('Unknown Merchant', undefined, new Decimal(0));
 
             expect(result.account).toBe('TODO:account');
             expect(result.source).toBe('default');

--- a/src/extension/import/__tests__/TabularDataParser.test.ts
+++ b/src/extension/import/__tests__/TabularDataParser.test.ts
@@ -215,6 +215,35 @@ describe('TabularDataParser', () => {
                 expect(result.value.rows).toHaveLength(2);
             }
         });
+
+        it('should parse quoted values that span multiple physical lines', () => {
+            const content = `Date,Description,Amount
+2024-01-15,"First line
+second line",5.50
+2024-01-16,Gas Station,30.00`;
+
+            const result = parser.parse(content);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.value.rows[0]!.cells).toEqual(['2024-01-15', 'First line\nsecond line', '5.50']);
+                expect(result.value.rows[0]!.lineNumber).toBe(2);
+                expect(result.value.rows[1]!.lineNumber).toBe(4);
+            }
+        });
+
+        it('should preserve escaped quotes adjacent to a newline inside quoted values', () => {
+            const content = `Date,Description,Amount
+2024-01-15,"First line ""
+second line",5.50`;
+
+            const result = parser.parse(content);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.value.rows[0]!.cells[1]).toBe('First line "\nsecond line');
+            }
+        });
     });
 
     describe('error handling', () => {
@@ -239,6 +268,20 @@ describe('TabularDataParser', () => {
             const result = parser.parse(content);
             expect(result.success).toBe(false);
         });
+
+        it('should report the starting physical line for an unclosed multiline quote', () => {
+            const content = `Date,Description,Amount
+2024-01-15,Grocery Store,50.00
+2024-01-16,"Unclosed quote
+that continues`;
+
+            const result = parser.parse(content);
+
+            expect(result.success).toBe(false);
+            if (result.success === false) {
+                expect(result.error).toBe('Error parsing line 3: Unclosed quote');
+            }
+        });
     });
 
     describe('explicit delimiter', () => {
@@ -251,6 +294,23 @@ describe('TabularDataParser', () => {
             if (result.success) {
                 expect(result.value.delimiter).toBe(';');
                 expect(result.value.headers).toEqual(['Date,Description', 'Amount']);
+            }
+        });
+    });
+
+    describe('delimiter detection with logical records', () => {
+        it('should ignore delimiters inside quoted multiline values', () => {
+            const content = `Date;Description;Amount
+2024-01-15;"Coffee, Bakery
+and Deli";5.50
+2024-01-16;Gas Station;30.00`;
+
+            const result = parser.parse(content);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.value.delimiter).toBe(';');
+                expect(result.value.rows[0]!.cells).toEqual(['2024-01-15', 'Coffee, Bakery\nand Deli', '5.50']);
             }
         });
     });

--- a/src/extension/import/__tests__/TransactionGenerator.test.ts
+++ b/src/extension/import/__tests__/TransactionGenerator.test.ts
@@ -1,5 +1,6 @@
 import { TransactionGenerator } from '../TransactionGenerator';
 import { ParsedTabularData, ColumnMapping, ParsedRow, DEFAULT_IMPORT_OPTIONS } from '../types';
+import stringWidth from 'string-width';
 
 describe('TransactionGenerator', () => {
     let generator: TransactionGenerator;
@@ -48,7 +49,7 @@ describe('TransactionGenerator', () => {
             expect(result.transactions).toHaveLength(1);
             expect(result.transactions[0]!.date).toBe('2024-01-15');
             expect(result.transactions[0]!.description).toBe('Grocery Store');
-            expect(result.transactions[0]!.amount).toBe(-50);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(-50);
         });
 
         it('should generate multiple transactions', () => {
@@ -127,8 +128,8 @@ describe('TransactionGenerator', () => {
             const result = generator.generate(data);
 
             expect(result.transactions).toHaveLength(2);
-            expect(result.transactions[0]!.amount).toBe(-50); // Debit is negative
-            expect(result.transactions[1]!.amount).toBe(100); // Credit is positive
+            expect(result.transactions[0]!.amount.toNumber()).toBe(-50); // Debit is negative
+            expect(result.transactions[1]!.amount.toNumber()).toBe(100); // Credit is positive
         });
     });
 
@@ -146,7 +147,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBeCloseTo(-1234.56);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(-1234.56);
         });
 
         it('should handle EU format (1.234,56)', () => {
@@ -162,7 +163,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBeCloseTo(-1234.56);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(-1234.56);
         });
 
         it('should handle currency symbols', () => {
@@ -178,7 +179,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBe(50);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(50);
         });
 
         it('should handle accounting notation (parentheses for negative)', () => {
@@ -194,7 +195,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBe(-50);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(-50);
         });
     });
 
@@ -216,7 +217,7 @@ describe('TransactionGenerator', () => {
 
             const result = invertingGenerator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBe(-50);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(-50);
         });
     });
 
@@ -460,7 +461,7 @@ describe('TransactionGenerator', () => {
             const result = generator.generate(data);
 
             expect(result.transactions).toHaveLength(1);
-            expect(result.transactions[0]!.amount).toBeGreaterThan(0);
+            expect(result.transactions[0]!.amount.isPositive()).toBe(true);
         });
 
         it('should reject amount strings over 100 characters', () => {
@@ -530,7 +531,7 @@ describe('TransactionGenerator', () => {
                 const result = generator.generate(data);
 
                 expect(result.transactions).toHaveLength(1);
-                expect(result.transactions[0]!.amount).toBeCloseTo(expected);
+                expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(expected);
             }
         });
     });
@@ -746,7 +747,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBeCloseTo(1.23);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(1.23);
         });
 
         it('should use heuristic by default (auto) - comma as thousand separator for >2 digits', () => {
@@ -762,7 +763,7 @@ describe('TransactionGenerator', () => {
 
             const result = generator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBe(1234);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(1234);
         });
 
         it('should treat comma as decimal separator when hint is "comma"', () => {
@@ -783,7 +784,7 @@ describe('TransactionGenerator', () => {
             const result = commaGenerator.generate(data);
 
             // With comma hint, "1,234" should be parsed as 1.234 (European decimal)
-            expect(result.transactions[0]!.amount).toBeCloseTo(1.234);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(1.234);
         });
 
         it('should treat comma as thousand separator when hint is "period"', () => {
@@ -804,7 +805,7 @@ describe('TransactionGenerator', () => {
             const result = periodGenerator.generate(data);
 
             // With period hint, "1,23" should be parsed as 123 (comma is thousand separator)
-            expect(result.transactions[0]!.amount).toBe(123);
+            expect(result.transactions[0]!.amount.toNumber()).toBe(123);
         });
 
         it('should handle explicit auto hint same as default', () => {
@@ -824,7 +825,7 @@ describe('TransactionGenerator', () => {
 
             const result = autoGenerator.generate(data);
 
-            expect(result.transactions[0]!.amount).toBeCloseTo(1.23);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(1.23);
         });
 
         it('should not affect parsing when period is clearly decimal', () => {
@@ -845,7 +846,7 @@ describe('TransactionGenerator', () => {
             const result = commaGenerator.generate(data);
 
             // Period as last separator should still be treated as decimal
-            expect(result.transactions[0]!.amount).toBeCloseTo(1234.56);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(1234.56);
         });
 
         it('should not affect EU format with both separators', () => {
@@ -866,7 +867,7 @@ describe('TransactionGenerator', () => {
             const result = periodGenerator.generate(data);
 
             // When both separators present, comma after period = EU format
-            expect(result.transactions[0]!.amount).toBeCloseTo(1234.56);
+            expect(result.transactions[0]!.amount.toNumber()).toBeCloseTo(1234.56);
         });
     });
 
@@ -970,5 +971,123 @@ describe('TransactionGenerator', () => {
             expect(result.transactions[0]!.date).toBe('2024-03-04');
             expect(result.warnings.some(w => w.message.includes('Ambiguous'))).toBe(false);
         });
+    });
+
+    describe('exact decimal amounts and display-width alignment', () => {
+        it('preserves values beyond IEEE-754 precision', () => {
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Amount'],
+                [['2024-01-15', 'Precision', '9007199254740993.01']],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'amount', index: 2 },
+                ])
+            ));
+
+            expect(result.transactions[0]!.amount.toString()).toBe('9007199254740993.01');
+            expect(result.transactions[0]!.amountFormatted).toBe('9007199254740993.01');
+        });
+
+        it('formats at least two decimal places without rounding away extra precision', () => {
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Amount'],
+                [['2024-01-15', 'Precision', '1.2345']],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'amount', index: 2 },
+                ])
+            ));
+
+            expect(result.transactions[0]!.amountFormatted).toBe('1.2345');
+        });
+
+        it('subtracts a 100-character debit from a 100-character credit exactly', () => {
+            const credit = '9'.repeat(100);
+            const debit = `0.${'0'.repeat(97)}1`;
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Debit', 'Credit'],
+                [['2024-01-15', 'Precision', debit, credit]],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'debit', index: 2 },
+                    { type: 'credit', index: 3 },
+                ])
+            ));
+
+            expect(result.transactions[0]!.amount.toFixed(98)).toBe(`${'9'.repeat(99)}8.${'9'.repeat(98)}`);
+        });
+
+        it.each(['1e10000', '12abc', '1.2.3'])('rejects malformed normalized amount %s', (amount) => {
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Amount'],
+                [['2024-01-15', 'Invalid', amount]],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'amount', index: 2 },
+                ])
+            ));
+
+            expect(result.transactions).toHaveLength(0);
+        });
+
+        it.each([
+            ['12abc', '20'],
+            ['10', '1e10000'],
+        ])('rejects a row when one non-empty debit/credit value is invalid', (debit, credit) => {
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Debit', 'Credit'],
+                [['2024-01-15', 'Invalid', debit, credit]],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'debit', index: 2 },
+                    { type: 'credit', index: 3 },
+                ])
+            ));
+
+            expect(result.transactions).toHaveLength(0);
+            expect(result.warnings.some((warning) => warning.message.includes('Invalid amount'))).toBe(true);
+        });
+
+        it.each([
+            ['.5', '0.50'],
+            ['1.', '1.00'],
+        ])('preserves support for plain decimal form %s', (amount, expected) => {
+            const result = generator.generate(createData(
+                ['Date', 'Description', 'Amount'],
+                [['2024-01-15', 'Compatible', amount]],
+                createMappings([
+                    { type: 'date', index: 0 },
+                    { type: 'description', index: 1 },
+                    { type: 'amount', index: 2 },
+                ])
+            ));
+
+            expect(result.transactions[0]!.amountFormatted).toBe(expected);
+        });
+
+        it.each(['assets:cash', '資産:現金', 'assets:cafe\u0301', 'assets:😀'])(
+            'aligns the amount at display column 52 for %s',
+            (account) => {
+                const alignedGenerator = new TransactionGenerator({ defaultDebitAccount: account });
+                const result = alignedGenerator.generate(createData(
+                    ['Date', 'Description', 'Amount'],
+                    [['2024-01-15', 'Width', '-1']],
+                    createMappings([
+                        { type: 'date', index: 0 },
+                        { type: 'description', index: 1 },
+                        { type: 'amount', index: 2 },
+                    ])
+                ));
+                const transaction = result.transactions[0]!;
+                const posting = alignedGenerator.formatTransaction(transaction, false).split('\n')[1]!;
+
+                expect(stringWidth(posting.slice(0, posting.lastIndexOf(transaction.amountFormatted))) + stringWidth(transaction.amountFormatted)).toBe(52);
+            }
+        );
     });
 });

--- a/src/extension/import/types.ts
+++ b/src/extension/import/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { AccountName, PayeeName, UsageCount } from '../types';
+import Decimal from 'decimal.js';
 
 /**
  * Payee-to-account mapping from journal history.
@@ -76,7 +77,7 @@ export interface AccountResolution {
 export interface ImportedTransaction {
     readonly date: string; // YYYY-MM-DD format
     readonly description: string;
-    readonly amount: number;
+    readonly amount: Decimal;
     readonly amountFormatted: string;
     readonly currency?: string;
     readonly sourceAccount: AccountResolution;


### PR DESCRIPTION
## Purpose

Complete the remaining import fixes from #218: preserve RFC 4180 multiline records, avoid lossy JavaScript number arithmetic, and align postings by display width.

## Changes

- parse quoted multiline CSV fields as logical records while preserving their starting physical line numbers
- keep imported amounts in bounded `Decimal` values, reject malformed and exponent notation, and preserve precision through debit/credit arithmetic and journal formatting
- calculate posting padding with Unicode display width for CJK, combining marks, and emoji
- add runtime dependencies on `decimal.js` and `string-width`

## Verification

- `npm run compile`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --runInBand` — 734 tests passed
- `npm run build`
- `npx vsce package`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- independent code review — approved

## Code landmarks

- `src/extension/import/TabularDataParser.ts` — logical CSV record scanner
- `src/extension/import/TransactionGenerator.ts` — exact amount parsing, arithmetic, formatting, and display-width padding
- `src/extension/import/types.ts` — imported amount model

Closes #218