### PR TITLE
fix(keybindings): prioritize HLedger shortcuts in journal files

### DIFF
--- a/docs/walkthrough/keybindings.md
+++ b/docs/walkthrough/keybindings.md
@@ -13,6 +13,16 @@ Set or cycle the transaction/posting status marker (`*`, `!`, or none):
 | `Cmd+K 1` | `Ctrl+K 1` | Set status to pending (`!`) |
 | `Cmd+K 2` | `Ctrl+K 2` | Set status to cleared (`*`) |
 
+These shortcuts are disabled by default. Enable them with the following setting:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `hledger.keybindings.transactionStatus` | `false` | Enable status keybindings |
+
+The status commands remain available in the Command Palette. To use different
+shortcuts, open **Preferences: Open Keyboard Shortcuts**, search for `HLedger`,
+and assign your preferred bindings.
+
 Example:
 
 ```hledger
@@ -40,10 +50,10 @@ Press **Enter** after a payee name to accept the ghost text suggestion and inser
 
 ## Status bar hints
 
-When editing an hledger file, the status bar shows a quick reference:
+When editing an hledger file, the status bar shows a quick reference. It includes the status shortcut only when `hledger.keybindings.transactionStatus` is enabled:
 
 ```
-⌘K S: status · Tab: align · Enter: suggest
+Tab: align · Enter: suggest
 ```
 
 ---

--- a/docs/walkthrough/keybindings.md
+++ b/docs/walkthrough/keybindings.md
@@ -25,7 +25,9 @@ Example:
 
 ## Tab: align amount
 
-Press **Tab** after typing an account name to move the cursor to the amount column. Amounts are aligned automatically on save when `editor.formatOnType` is enabled.
+Press **Tab** to accept a visible inline suggestion. Otherwise, after typing an
+account name, it moves the cursor to the amount column. Amounts are aligned
+automatically on save when `editor.formatOnType` is enabled.
 
 | Setting | Default | Description |
 |---------|---------|-------------|

--- a/docs/walkthrough/keybindings.md
+++ b/docs/walkthrough/keybindings.md
@@ -1,6 +1,8 @@
 # Keyboard Shortcuts
 
 The extension provides keybindings for common editing tasks in hledger files.
+HLedger owns **Enter** and **Tab** in hledger editors, including while inline
+suggestions are visible. Your user keybindings can override these defaults.
 
 ## Status keybindings
 
@@ -12,16 +14,6 @@ Set or cycle the transaction/posting status marker (`*`, `!`, or none):
 | `Cmd+K 0` | `Ctrl+K 0` | Set status to unmarked |
 | `Cmd+K 1` | `Ctrl+K 1` | Set status to pending (`!`) |
 | `Cmd+K 2` | `Ctrl+K 2` | Set status to cleared (`*`) |
-
-These shortcuts are disabled by default. Enable them with the following setting:
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `hledger.keybindings.transactionStatus` | `false` | Enable status keybindings |
-
-The status commands remain available in the Command Palette. To use different
-shortcuts, open **Preferences: Open Keyboard Shortcuts**, search for `HLedger`,
-and assign your preferred bindings.
 
 Example:
 
@@ -50,10 +42,10 @@ Press **Enter** after a payee name to accept the ghost text suggestion and inser
 
 ## Status bar hints
 
-When editing an hledger file, the status bar shows a quick reference. It includes the status shortcut only when `hledger.keybindings.transactionStatus` is enabled:
+When editing an hledger file, the status bar shows a quick reference:
 
 ```
-Tab: align · Enter: suggest
+⌘K S: status · Tab: align · Enter: suggest
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -258,11 +258,6 @@
           "default": true,
           "description": "Rebind Tab in hledger files to align amounts via the Language Server (disable to restore default VS Code Tab behavior)"
         },
-        "hledger.keybindings.transactionStatus": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable keybindings for cycling and setting transaction status in hledger files"
-        },
         "hledger.completion.snippets": {
           "type": "boolean",
           "default": true,
@@ -511,12 +506,12 @@
       {
         "command": "hledger.editor.enterAndSuggest",
         "key": "enter",
-        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && config.hledger.keybindings.enterAndSuggest"
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inSnippetMode && config.hledger.keybindings.enterAndSuggest"
       },
       {
         "command": "hledger.editor.alignAmount",
         "key": "tab",
-        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
       },
       {
         "command": "hledger.editor.cycleStatus",
@@ -524,7 +519,7 @@
         "mac": "cmd+k s",
         "win": "ctrl+k s",
         "linux": "ctrl+k s",
-        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
+        "when": "editorTextFocus && editorLangId == hledger"
       },
       {
         "command": "hledger.editor.setStatusUnmarked",
@@ -532,7 +527,7 @@
         "mac": "cmd+k 0",
         "win": "ctrl+k 0",
         "linux": "ctrl+k 0",
-        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
+        "when": "editorTextFocus && editorLangId == hledger"
       },
       {
         "command": "hledger.editor.setStatusPending",
@@ -540,7 +535,7 @@
         "mac": "cmd+k 1",
         "win": "ctrl+k 1",
         "linux": "ctrl+k 1",
-        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
+        "when": "editorTextFocus && editorLangId == hledger"
       },
       {
         "command": "hledger.editor.setStatusCleared",
@@ -548,7 +543,7 @@
         "mac": "cmd+k 2",
         "win": "ctrl+k 2",
         "linux": "ctrl+k 2",
-        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
+        "when": "editorTextFocus && editorLangId == hledger"
       }
     ],
     "configurationDefaults": {

--- a/package.json
+++ b/package.json
@@ -509,9 +509,14 @@
         "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inSnippetMode && config.hledger.keybindings.enterAndSuggest"
       },
       {
+        "command": "editor.action.inlineSuggest.commit",
+        "key": "tab",
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inSnippetMode && inlineSuggestionVisible"
+      },
+      {
         "command": "hledger.editor.alignAmount",
         "key": "tab",
-        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
+        "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
       },
       {
         "command": "hledger.editor.cycleStatus",

--- a/package.json
+++ b/package.json
@@ -258,6 +258,11 @@
           "default": true,
           "description": "Rebind Tab in hledger files to align amounts via the Language Server (disable to restore default VS Code Tab behavior)"
         },
+        "hledger.keybindings.transactionStatus": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable keybindings for cycling and setting transaction status in hledger files"
+        },
         "hledger.completion.snippets": {
           "type": "boolean",
           "default": true,
@@ -519,7 +524,7 @@
         "mac": "cmd+k s",
         "win": "ctrl+k s",
         "linux": "ctrl+k s",
-        "when": "editorTextFocus && editorLangId == hledger"
+        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
       },
       {
         "command": "hledger.editor.setStatusUnmarked",
@@ -527,7 +532,7 @@
         "mac": "cmd+k 0",
         "win": "ctrl+k 0",
         "linux": "ctrl+k 0",
-        "when": "editorTextFocus && editorLangId == hledger"
+        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
       },
       {
         "command": "hledger.editor.setStatusPending",
@@ -535,7 +540,7 @@
         "mac": "cmd+k 1",
         "win": "ctrl+k 1",
         "linux": "ctrl+k 1",
-        "when": "editorTextFocus && editorLangId == hledger"
+        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
       },
       {
         "command": "hledger.editor.setStatusCleared",
@@ -543,7 +548,7 @@
         "mac": "cmd+k 2",
         "win": "ctrl+k 2",
         "linux": "ctrl+k 2",
-        "when": "editorTextFocus && editorLangId == hledger"
+        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.transactionStatus"
       }
     ],
     "configurationDefaults": {

--- a/src/extension/KeybindingHintsStatusBar.ts
+++ b/src/extension/KeybindingHintsStatusBar.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 
 const HLEDGER_LANGUAGE_ID = 'hledger';
-const TRANSACTION_STATUS_KEYBINDINGS_SETTING =
-  'hledger.keybindings.transactionStatus';
 
 export class KeybindingHintsStatusBar implements vscode.Disposable {
   private readonly item: vscode.StatusBarItem;
@@ -13,6 +11,8 @@ export class KeybindingHintsStatusBar implements vscode.Disposable {
       vscode.StatusBarAlignment.Right,
       99
     );
+    this.item.text = '$(keyboard) ⌘K S: status · Tab: align · Enter: suggest';
+    this.item.tooltip = 'HLedger keybindings: Cmd+K S cycles status, Tab aligns amount, Enter accepts suggestion';
     this.item.name = 'HLedger Keybinding Hints';
 
     this.disposables.push(
@@ -20,33 +20,7 @@ export class KeybindingHintsStatusBar implements vscode.Disposable {
         this.updateVisibility(editor);
       })
     );
-    this.disposables.push(
-      vscode.workspace.onDidChangeConfiguration((event) => {
-        if (event.affectsConfiguration(TRANSACTION_STATUS_KEYBINDINGS_SETTING)) {
-          this.updateHints();
-        }
-      })
-    );
-
-    this.updateHints();
     this.updateVisibility(vscode.window.activeTextEditor);
-  }
-
-  private updateHints(): void {
-    const transactionStatusKeybindingsEnabled = vscode.workspace
-      .getConfiguration('hledger')
-      .get<boolean>('keybindings.transactionStatus', false);
-
-    if (transactionStatusKeybindingsEnabled) {
-      this.item.text = '$(keyboard) ⌘K S: status · Tab: align · Enter: suggest';
-      this.item.tooltip =
-        'HLedger keybindings: Cmd+K S cycles status, Tab aligns amount, Enter accepts suggestion';
-      return;
-    }
-
-    this.item.text = '$(keyboard) Tab: align · Enter: suggest';
-    this.item.tooltip =
-      'HLedger keybindings: Tab aligns amount, Enter accepts suggestion';
   }
 
   private updateVisibility(editor: vscode.TextEditor | undefined): void {

--- a/src/extension/KeybindingHintsStatusBar.ts
+++ b/src/extension/KeybindingHintsStatusBar.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 
 const HLEDGER_LANGUAGE_ID = 'hledger';
+const TRANSACTION_STATUS_KEYBINDINGS_SETTING =
+  'hledger.keybindings.transactionStatus';
 
 export class KeybindingHintsStatusBar implements vscode.Disposable {
   private readonly item: vscode.StatusBarItem;
@@ -11,8 +13,6 @@ export class KeybindingHintsStatusBar implements vscode.Disposable {
       vscode.StatusBarAlignment.Right,
       99
     );
-    this.item.text = '$(keyboard) ⌘K S: status · Tab: align · Enter: suggest';
-    this.item.tooltip = 'HLedger keybindings: Cmd+K S cycles status, Tab aligns amount, Enter accepts suggestion';
     this.item.name = 'HLedger Keybinding Hints';
 
     this.disposables.push(
@@ -20,8 +20,33 @@ export class KeybindingHintsStatusBar implements vscode.Disposable {
         this.updateVisibility(editor);
       })
     );
+    this.disposables.push(
+      vscode.workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration(TRANSACTION_STATUS_KEYBINDINGS_SETTING)) {
+          this.updateHints();
+        }
+      })
+    );
 
+    this.updateHints();
     this.updateVisibility(vscode.window.activeTextEditor);
+  }
+
+  private updateHints(): void {
+    const transactionStatusKeybindingsEnabled = vscode.workspace
+      .getConfiguration('hledger')
+      .get<boolean>('keybindings.transactionStatus', false);
+
+    if (transactionStatusKeybindingsEnabled) {
+      this.item.text = '$(keyboard) ⌘K S: status · Tab: align · Enter: suggest';
+      this.item.tooltip =
+        'HLedger keybindings: Cmd+K S cycles status, Tab aligns amount, Enter accepts suggestion';
+      return;
+    }
+
+    this.item.text = '$(keyboard) Tab: align · Enter: suggest';
+    this.item.tooltip =
+      'HLedger keybindings: Tab aligns amount, Enter accepts suggestion';
   }
 
   private updateVisibility(editor: vscode.TextEditor | undefined): void {

--- a/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
+++ b/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
@@ -5,10 +5,16 @@ describe('KeybindingHintsStatusBar', () => {
   let statusBar: KeybindingHintsStatusBar;
   let mockItem: any;
   let editorChangeCallback: ((editor: any) => void) | undefined;
+  let configurationChangeCallback:
+    | ((event: vscode.ConfigurationChangeEvent) => void)
+    | undefined;
+  let transactionStatusKeybindingsEnabled: boolean;
 
   beforeEach(() => {
     jest.clearAllMocks();
     editorChangeCallback = undefined;
+    configurationChangeCallback = undefined;
+    transactionStatusKeybindingsEnabled = false;
 
     (vscode.window as any).activeTextEditor = undefined;
 
@@ -28,6 +34,20 @@ describe('KeybindingHintsStatusBar', () => {
         return { dispose: jest.fn() };
       }
     );
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        if (key === 'keybindings.transactionStatus') {
+          return transactionStatusKeybindingsEnabled;
+        }
+        return defaultValue;
+      }),
+    });
+    (vscode.workspace.onDidChangeConfiguration as jest.Mock).mockImplementation(
+      (callback: (event: vscode.ConfigurationChangeEvent) => void) => {
+        configurationChangeCallback = callback;
+        return { dispose: jest.fn() };
+      }
+    );
   });
 
   afterEach(() => {
@@ -44,18 +64,28 @@ describe('KeybindingHintsStatusBar', () => {
       );
     });
 
-    it('should set keybinding hints text', () => {
+    it('should not advertise disabled status keybindings', () => {
       statusBar = new KeybindingHintsStatusBar();
 
-      expect(mockItem.text).toContain('status');
+      expect(mockItem.text).not.toContain('status');
+      expect(mockItem.text).not.toContain('⌘K S');
       expect(mockItem.text).toContain('align');
       expect(mockItem.text).toContain('suggest');
+    });
+
+    it('should advertise status keybindings when enabled', () => {
+      transactionStatusKeybindingsEnabled = true;
+      statusBar = new KeybindingHintsStatusBar();
+
+      expect(mockItem.text).toContain('⌘K S');
+      expect(mockItem.text).toContain('status');
+      expect(mockItem.tooltip).toContain('Cmd+K S');
     });
 
     it('should set tooltip', () => {
       statusBar = new KeybindingHintsStatusBar();
 
-      expect(mockItem.tooltip).toContain('Cmd+K S');
+      expect(mockItem.tooltip).not.toContain('Cmd+K S');
       expect(mockItem.tooltip).toContain('Tab');
       expect(mockItem.tooltip).toContain('Enter');
     });
@@ -71,6 +101,19 @@ describe('KeybindingHintsStatusBar', () => {
 
       expect(vscode.window.onDidChangeActiveTextEditor).toHaveBeenCalled();
       expect(editorChangeCallback).toBeDefined();
+    });
+
+    it('should update status keybinding hints after configuration changes', () => {
+      statusBar = new KeybindingHintsStatusBar();
+
+      transactionStatusKeybindingsEnabled = true;
+      configurationChangeCallback!({
+        affectsConfiguration: (section: string) =>
+          section === 'hledger.keybindings.transactionStatus',
+      });
+
+      expect(mockItem.text).toContain('⌘K S');
+      expect(mockItem.tooltip).toContain('Cmd+K S');
     });
   });
 

--- a/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
+++ b/src/extension/__tests__/KeybindingHintsStatusBar.test.ts
@@ -5,16 +5,10 @@ describe('KeybindingHintsStatusBar', () => {
   let statusBar: KeybindingHintsStatusBar;
   let mockItem: any;
   let editorChangeCallback: ((editor: any) => void) | undefined;
-  let configurationChangeCallback:
-    | ((event: vscode.ConfigurationChangeEvent) => void)
-    | undefined;
-  let transactionStatusKeybindingsEnabled: boolean;
 
   beforeEach(() => {
     jest.clearAllMocks();
     editorChangeCallback = undefined;
-    configurationChangeCallback = undefined;
-    transactionStatusKeybindingsEnabled = false;
 
     (vscode.window as any).activeTextEditor = undefined;
 
@@ -34,20 +28,6 @@ describe('KeybindingHintsStatusBar', () => {
         return { dispose: jest.fn() };
       }
     );
-    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
-      get: jest.fn((key: string, defaultValue?: unknown) => {
-        if (key === 'keybindings.transactionStatus') {
-          return transactionStatusKeybindingsEnabled;
-        }
-        return defaultValue;
-      }),
-    });
-    (vscode.workspace.onDidChangeConfiguration as jest.Mock).mockImplementation(
-      (callback: (event: vscode.ConfigurationChangeEvent) => void) => {
-        configurationChangeCallback = callback;
-        return { dispose: jest.fn() };
-      }
-    );
   });
 
   afterEach(() => {
@@ -64,28 +44,19 @@ describe('KeybindingHintsStatusBar', () => {
       );
     });
 
-    it('should not advertise disabled status keybindings', () => {
+    it('should set keybinding hints text', () => {
       statusBar = new KeybindingHintsStatusBar();
 
-      expect(mockItem.text).not.toContain('status');
-      expect(mockItem.text).not.toContain('⌘K S');
+      expect(mockItem.text).toContain('status');
+      expect(mockItem.text).toContain('⌘K S');
       expect(mockItem.text).toContain('align');
       expect(mockItem.text).toContain('suggest');
-    });
-
-    it('should advertise status keybindings when enabled', () => {
-      transactionStatusKeybindingsEnabled = true;
-      statusBar = new KeybindingHintsStatusBar();
-
-      expect(mockItem.text).toContain('⌘K S');
-      expect(mockItem.text).toContain('status');
-      expect(mockItem.tooltip).toContain('Cmd+K S');
     });
 
     it('should set tooltip', () => {
       statusBar = new KeybindingHintsStatusBar();
 
-      expect(mockItem.tooltip).not.toContain('Cmd+K S');
+      expect(mockItem.tooltip).toContain('Cmd+K S');
       expect(mockItem.tooltip).toContain('Tab');
       expect(mockItem.tooltip).toContain('Enter');
     });
@@ -103,18 +74,6 @@ describe('KeybindingHintsStatusBar', () => {
       expect(editorChangeCallback).toBeDefined();
     });
 
-    it('should update status keybinding hints after configuration changes', () => {
-      statusBar = new KeybindingHintsStatusBar();
-
-      transactionStatusKeybindingsEnabled = true;
-      configurationChangeCallback!({
-        affectsConfiguration: (section: string) =>
-          section === 'hledger.keybindings.transactionStatus',
-      });
-
-      expect(mockItem.text).toContain('⌘K S');
-      expect(mockItem.tooltip).toContain('Cmd+K S');
-    });
   });
 
   describe('visibility', () => {

--- a/src/extension/__tests__/keybindings.test.ts
+++ b/src/extension/__tests__/keybindings.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 interface KeybindingContribution {
   command: string;
+  key?: string;
   when?: string;
 }
 
@@ -25,16 +26,34 @@ describe('keybinding contributions', () => {
     fs.readFileSync(packageJsonPath, 'utf-8')
   ) as ExtensionManifest;
 
-  it('keeps transaction status keybindings disabled by default', () => {
-    const setting =
-      pkg.contributes?.configuration?.properties?.[
-        'hledger.keybindings.transactionStatus'
-      ];
+  const getKeybinding = (command: string): KeybindingContribution | undefined =>
+    pkg.contributes?.keybindings?.find(
+      (keybinding) => keybinding.command === command
+    );
 
-    expect(setting?.default).toBe(false);
+  it('keeps Enter and Tab overrides enabled by default', () => {
+    const properties = pkg.contributes?.configuration?.properties;
+
+    expect(properties?.['hledger.keybindings.enterAndSuggest']?.default).toBe(
+      true
+    );
+    expect(properties?.['hledger.keybindings.alignAmount']?.default).toBe(true);
   });
 
-  it('guards every transaction status keybinding with the opt-in setting', () => {
+  it('claims Enter and Tab for hledger when inline suggestions are visible', () => {
+    const enterKeybinding = getKeybinding('hledger.editor.enterAndSuggest');
+    const tabKeybinding = getKeybinding('hledger.editor.alignAmount');
+
+    expect(enterKeybinding?.key).toBe('enter');
+    expect(enterKeybinding?.when).toContain('editorLangId == hledger');
+    expect(enterKeybinding?.when).not.toContain('!inlineSuggestionVisible');
+
+    expect(tabKeybinding?.key).toBe('tab');
+    expect(tabKeybinding?.when).toContain('editorLangId == hledger');
+    expect(tabKeybinding?.when).not.toContain('!inlineSuggestionVisible');
+  });
+
+  it('keeps transaction status keybindings active in hledger editors', () => {
     const statusCommands = new Set([
       'hledger.editor.cycleStatus',
       'hledger.editor.setStatusUnmarked',
@@ -47,9 +66,16 @@ describe('keybinding contributions', () => {
 
     expect(statusKeybindings).toHaveLength(statusCommands.size);
     for (const keybinding of statusKeybindings) {
-      expect(keybinding.when).toContain(
+      expect(keybinding.when).toContain('editorLangId == hledger');
+      expect(keybinding.when).not.toContain(
         'config.hledger.keybindings.transactionStatus'
       );
     }
+
+    expect(
+      pkg.contributes?.configuration?.properties?.[
+        'hledger.keybindings.transactionStatus'
+      ]
+    ).toBeUndefined();
   });
 });

--- a/src/extension/__tests__/keybindings.test.ts
+++ b/src/extension/__tests__/keybindings.test.ts
@@ -40,17 +40,27 @@ describe('keybinding contributions', () => {
     expect(properties?.['hledger.keybindings.alignAmount']?.default).toBe(true);
   });
 
-  it('claims Enter and Tab for hledger when inline suggestions are visible', () => {
+  it('claims Enter for hledger when inline suggestions are visible', () => {
     const enterKeybinding = getKeybinding('hledger.editor.enterAndSuggest');
-    const tabKeybinding = getKeybinding('hledger.editor.alignAmount');
 
     expect(enterKeybinding?.key).toBe('enter');
     expect(enterKeybinding?.when).toContain('editorLangId == hledger');
     expect(enterKeybinding?.when).not.toContain('!inlineSuggestionVisible');
+  });
 
-    expect(tabKeybinding?.key).toBe('tab');
-    expect(tabKeybinding?.when).toContain('editorLangId == hledger');
-    expect(tabKeybinding?.when).not.toContain('!inlineSuggestionVisible');
+  it('commits a visible inline suggestion with Tab and aligns otherwise', () => {
+    const commitKeybinding = getKeybinding(
+      'editor.action.inlineSuggest.commit'
+    );
+    const alignKeybinding = getKeybinding('hledger.editor.alignAmount');
+
+    expect(commitKeybinding?.key).toBe('tab');
+    expect(commitKeybinding?.when).toContain('editorLangId == hledger');
+    expect(commitKeybinding?.when).toContain('inlineSuggestionVisible');
+
+    expect(alignKeybinding?.key).toBe('tab');
+    expect(alignKeybinding?.when).toContain('editorLangId == hledger');
+    expect(alignKeybinding?.when).toContain('!inlineSuggestionVisible');
   });
 
   it('keeps transaction status keybindings active in hledger editors', () => {

--- a/src/extension/__tests__/keybindings.test.ts
+++ b/src/extension/__tests__/keybindings.test.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface KeybindingContribution {
+  command: string;
+  when?: string;
+}
+
+interface ConfigurationProperty {
+  default?: unknown;
+}
+
+interface ExtensionManifest {
+  contributes?: {
+    configuration?: {
+      properties?: Record<string, ConfigurationProperty>;
+    };
+    keybindings?: KeybindingContribution[];
+  };
+}
+
+describe('keybinding contributions', () => {
+  const packageJsonPath = path.resolve(__dirname, '../../../package.json');
+  const pkg = JSON.parse(
+    fs.readFileSync(packageJsonPath, 'utf-8')
+  ) as ExtensionManifest;
+
+  it('keeps transaction status keybindings disabled by default', () => {
+    const setting =
+      pkg.contributes?.configuration?.properties?.[
+        'hledger.keybindings.transactionStatus'
+      ];
+
+    expect(setting?.default).toBe(false);
+  });
+
+  it('guards every transaction status keybinding with the opt-in setting', () => {
+    const statusCommands = new Set([
+      'hledger.editor.cycleStatus',
+      'hledger.editor.setStatusUnmarked',
+      'hledger.editor.setStatusPending',
+      'hledger.editor.setStatusCleared',
+    ]);
+    const statusKeybindings = (pkg.contributes?.keybindings ?? []).filter(
+      ({ command }) => statusCommands.has(command)
+    );
+
+    expect(statusKeybindings).toHaveLength(statusCommands.size);
+    for (const keybinding of statusKeybindings) {
+      expect(keybinding.when).toContain(
+        'config.hledger.keybindings.transactionStatus'
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Purpose

Prevent Enter and Tab conflicts with other extensions while editing HLedger journal files.

## Changes

- Keep HLedger Enter behavior active when inline suggestions are visible.
- Use Tab to accept a visible inline suggestion.
- Use Tab to align the amount when no inline suggestion is visible.
- Keep transaction status shortcuts enabled in HLedger editors.
- Document the shortcut precedence.

## Verification

- `npm test -- --runInBand` — 34 suites, 738 tests passed.
- `npm run lint`.
- `npm run typecheck`.
- `npm run build`.

## Code landmarks

- `package.json` — HLedger-scoped Enter and Tab keybindings.
- `src/extension/__tests__/keybindings.test.ts` — keybinding precedence tests.
- `docs/walkthrough/keybindings.md` — user-facing shortcut behavior.

Closes #236
