### PR TITLE
fix(lsp): verify updates without stopping the running server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "blakejs": "1.2.1",
         "decimal.js": "^10.6.0",
         "string-width": "^4.2.3",
         "undici": "^6.27.0",
@@ -3806,6 +3807,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -730,6 +730,7 @@
   "homepage": "https://github.com/juev/hledger-vscode#readme",
   "icon": "images/icon.png",
   "dependencies": {
+    "blakejs": "1.2.1",
     "decimal.js": "^10.6.0",
     "string-width": "^4.2.3",
     "undici": "^6.27.0",

--- a/src/extension/lsp/BinaryManager.ts
+++ b/src/extension/lsp/BinaryManager.ts
@@ -497,7 +497,10 @@ export class BinaryManager {
     return hash.digest("hex") === expectedHash.toLowerCase();
   }
 
-  async download(onProgress?: (percent: number) => void): Promise<void> {
+  async download(
+    onProgress?: (percent: number) => void,
+    beforeInstall?: () => Promise<void>,
+  ): Promise<void> {
     // Progress allocation: 5% release info, 5% checksums, 85% download, 5% verify/write
     onProgress?.(5);
     const release = await this.getLatestRelease();
@@ -580,6 +583,11 @@ export class BinaryManager {
       } finally {
         await fd.close();
       }
+
+      // Keep the currently running server alive until the candidate binary has
+      // passed all checks and has been staged. This also lets Windows release
+      // the executable before the atomic replacement.
+      await beforeInstall?.();
 
       // Atomic rename: version file first, then binary (safer to have missing version than missing binary)
       await fs.promises.rename(tempVersionPath, versionPath);

--- a/src/extension/lsp/HLedgerLanguageClient.ts
+++ b/src/extension/lsp/HLedgerLanguageClient.ts
@@ -149,7 +149,10 @@ export function createClientOptions(): LanguageClientOptions {
   const lspSettings = mapVSCodeSettingsToLSP(vsCodeSettings);
 
   return {
-    documentSelector: [{ language: "hledger" }, { language: "hledger-rules" }],
+    documentSelector: [
+      { scheme: "file", language: "hledger" },
+      { scheme: "file", language: "hledger-rules" },
+    ],
     initializationOptions: lspSettings,
     synchronize: {
       configurationSection: "hledger",

--- a/src/extension/lsp/LSPManager.ts
+++ b/src/extension/lsp/LSPManager.ts
@@ -14,6 +14,9 @@ export interface LSPManagerLike {
   download(
     progress?: vscode.Progress<{ message?: string; increment?: number }>
   ): Promise<void>;
+  update(
+    progress?: vscode.Progress<{ message?: string; increment?: number }>
+  ): Promise<void>;
   start(): Promise<void>;
   stop(): Promise<void>;
 }
@@ -103,18 +106,63 @@ export class LSPManager implements vscode.Disposable {
     this.setStatus(LSPStatus.Downloading);
 
     try {
-      progress?.report({ message: "Fetching latest release..." });
-      let previousPercent = 0;
-      await this.binaryManager.download((percent) => {
-        const delta = percent - previousPercent;
-        progress?.report({ message: `Downloading... ${percent}%`, increment: delta });
-        previousPercent = percent;
-      });
+      await this.downloadBinary(progress);
       this.setStatus(LSPStatus.Stopped);
     } catch (error) {
       this.setStatus(LSPStatus.Error);
       throw error;
     }
+  }
+
+  async update(
+    progress?: vscode.Progress<{ message?: string; increment?: number }>
+  ): Promise<void> {
+    const previousStatus = this.status;
+    const wasRunning =
+      this.client !== null &&
+      this.client.getState() === LanguageClientState.Running;
+    let stoppedForInstall = false;
+    let installCompleted = false;
+
+    this.setStatus(LSPStatus.Downloading);
+
+    try {
+      await this.downloadBinary(progress, async () => {
+        if (wasRunning) {
+          await this.stop();
+          stoppedForInstall = true;
+        }
+      });
+      installCompleted = true;
+      await this.start();
+    } catch (error) {
+      if (stoppedForInstall && !installCompleted) {
+        try {
+          await this.start();
+        } catch {
+          this.setStatus(LSPStatus.Error);
+        }
+      } else if (!stoppedForInstall) {
+        this.setStatus(previousStatus);
+      }
+      throw error;
+    }
+  }
+
+  private async downloadBinary(
+    progress?: vscode.Progress<{ message?: string; increment?: number }>,
+    beforeInstall?: () => Promise<void>,
+  ): Promise<void> {
+    progress?.report({ message: "Fetching latest release..." });
+    let previousPercent = 0;
+    await this.binaryManager.download((percent) => {
+      const delta = percent - previousPercent;
+      progress?.report({
+        message: `Downloading... ${percent}%`,
+        increment: delta,
+      });
+      previousPercent = percent;
+    }, beforeInstall);
   }
 
   async checkForUpdates(): Promise<{ hasUpdate: boolean; currentVersion: string | null; latestVersion: string }> {

--- a/src/extension/lsp/StartupChecker.ts
+++ b/src/extension/lsp/StartupChecker.ts
@@ -124,9 +124,7 @@ export class StartupChecker {
         cancellable: false,
       },
       async (progress) => {
-        await this.lspManager.stop();
-        await this.lspManager.download(progress);
-        await this.lspManager.start();
+        await this.lspManager.update(progress);
       }
     );
     vscode.window.showInformationMessage(

--- a/src/extension/lsp/__tests__/BinaryManager.test.ts
+++ b/src/extension/lsp/__tests__/BinaryManager.test.ts
@@ -1363,6 +1363,7 @@ describe("BinaryManager", () => {
   describe("signature verification", () => {
     it("rejects binary when signature verification fails", async () => {
       (verifyMinisign as jest.Mock).mockReturnValue(false);
+      const beforeInstall = jest.fn().mockResolvedValue(undefined);
 
       const binaryContent = Buffer.alloc(2048, "x");
       const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
@@ -1400,9 +1401,10 @@ describe("BinaryManager", () => {
 
       manager = new BinaryManager(tempDir, mockFetch);
 
-      await expect(manager.download()).rejects.toThrow(
+      await expect(manager.download(undefined, beforeInstall)).rejects.toThrow(
         /Signature verification failed/
       );
+      expect(beforeInstall).not.toHaveBeenCalled();
       expect(await manager.isInstalled()).toBe(false);
     });
 

--- a/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
+++ b/src/extension/lsp/__tests__/HLedgerLanguageClient.test.ts
@@ -44,8 +44,8 @@ describe("createClientOptions", () => {
     const options = createClientOptions();
 
     expect(options.documentSelector).toEqual([
-      { language: "hledger" },
-      { language: "hledger-rules" },
+      { scheme: "file", language: "hledger" },
+      { scheme: "file", language: "hledger-rules" },
     ]);
   });
 

--- a/src/extension/lsp/__tests__/LSPManager.test.ts
+++ b/src/extension/lsp/__tests__/LSPManager.test.ts
@@ -287,4 +287,77 @@ describe("LSPManager", () => {
       manager.dispose();
     });
   });
+
+  describe("update", () => {
+    it("keeps the running server when verification fails before installation", async () => {
+      const binaryPath = path.join(tempDir, "hledger-lsp");
+      fs.writeFileSync(binaryPath, "#!/bin/bash\necho test");
+      fs.chmodSync(binaryPath, 0o755);
+
+      const download = jest
+        .spyOn(BinaryManager.prototype, "download")
+        .mockRejectedValue(new Error("Signature verification failed"));
+      const manager = new LSPManager(mockContext);
+      await manager.start();
+      const runningClient = manager.getClient();
+
+      await expect(manager.update()).rejects.toThrow(
+        "Signature verification failed"
+      );
+
+      expect(manager.getClient()).toBe(runningClient);
+      expect(manager.getStatus()).toBe(LSPStatus.Running);
+
+      download.mockRestore();
+      manager.dispose();
+    });
+
+    it("stops the running server only after the binary is verified", async () => {
+      const binaryPath = path.join(tempDir, "hledger-lsp");
+      fs.writeFileSync(binaryPath, "#!/bin/bash\necho test");
+      fs.chmodSync(binaryPath, 0o755);
+
+      const manager = new LSPManager(mockContext);
+      await manager.start();
+      const runningClient = manager.getClient();
+      const download = jest
+        .spyOn(BinaryManager.prototype, "download")
+        .mockImplementation(async (_onProgress, beforeInstall) => {
+          expect(manager.getClient()).toBe(runningClient);
+          await beforeInstall?.();
+          expect(manager.getClient()).toBeNull();
+        });
+
+      await manager.update();
+
+      expect(manager.getStatus()).toBe(LSPStatus.Running);
+      expect(manager.getClient()).not.toBe(runningClient);
+
+      download.mockRestore();
+      manager.dispose();
+    });
+
+    it("restarts the old server when installation fails after it was stopped", async () => {
+      const binaryPath = path.join(tempDir, "hledger-lsp");
+      fs.writeFileSync(binaryPath, "#!/bin/bash\necho test");
+      fs.chmodSync(binaryPath, 0o755);
+
+      const manager = new LSPManager(mockContext);
+      await manager.start();
+      const download = jest
+        .spyOn(BinaryManager.prototype, "download")
+        .mockImplementation(async (_onProgress, beforeInstall) => {
+          await beforeInstall?.();
+          throw new Error("Atomic install failed");
+        });
+
+      await expect(manager.update()).rejects.toThrow("Atomic install failed");
+
+      expect(manager.getStatus()).toBe(LSPStatus.Running);
+      expect(manager.getClient()).not.toBeNull();
+
+      download.mockRestore();
+      manager.dispose();
+    });
+  });
 });

--- a/src/extension/lsp/__tests__/StartupChecker.test.ts
+++ b/src/extension/lsp/__tests__/StartupChecker.test.ts
@@ -10,6 +10,7 @@ interface MockLSPManager {
     }>
   >;
   download: jest.Mock<Promise<void>>;
+  update: jest.Mock<Promise<void>>;
   start: jest.Mock<Promise<void>>;
   stop: jest.Mock<Promise<void>>;
 }
@@ -26,6 +27,7 @@ describe("StartupChecker", () => {
       isServerAvailable: jest.fn(),
       checkForUpdates: jest.fn(),
       download: jest.fn(),
+      update: jest.fn(),
       start: jest.fn(),
       stop: jest.fn(),
     };
@@ -283,55 +285,27 @@ describe("StartupChecker", () => {
   });
 
   describe("performUpdate", () => {
-    it("stops, downloads, and starts the LSP server", async () => {
+    it("delegates the running-server update lifecycle to LSPManager", async () => {
       mockWithProgress.mockImplementation((_options: any, task: any) =>
         task({ report: jest.fn() })
       );
-      mockLSPManager.stop.mockResolvedValue(undefined);
-      mockLSPManager.download.mockResolvedValue(undefined);
-      mockLSPManager.start.mockResolvedValue(undefined);
+      mockLSPManager.update.mockResolvedValue(undefined);
 
       const checker = new StartupChecker(mockLSPManager, mockContext);
 
       await checker.performUpdate();
 
-      expect(mockLSPManager.stop).toHaveBeenCalled();
-      expect(mockLSPManager.download).toHaveBeenCalled();
-      expect(mockLSPManager.start).toHaveBeenCalled();
-    });
-
-    it("calls stop before download", async () => {
-      const callOrder: string[] = [];
-      mockWithProgress.mockImplementation((_options: any, task: any) =>
-        task({ report: jest.fn() })
-      );
-      mockLSPManager.stop.mockImplementation(() => {
-        callOrder.push("stop");
-        return Promise.resolve();
-      });
-      mockLSPManager.download.mockImplementation(() => {
-        callOrder.push("download");
-        return Promise.resolve();
-      });
-      mockLSPManager.start.mockImplementation(() => {
-        callOrder.push("start");
-        return Promise.resolve();
-      });
-
-      const checker = new StartupChecker(mockLSPManager, mockContext);
-
-      await checker.performUpdate();
-
-      expect(callOrder).toEqual(["stop", "download", "start"]);
+      expect(mockLSPManager.update).toHaveBeenCalled();
+      expect(mockLSPManager.stop).not.toHaveBeenCalled();
+      expect(mockLSPManager.download).not.toHaveBeenCalled();
+      expect(mockLSPManager.start).not.toHaveBeenCalled();
     });
 
     it("shows success notification after update", async () => {
       mockWithProgress.mockImplementation((_options: any, task: any) =>
         task({ report: jest.fn() })
       );
-      mockLSPManager.stop.mockResolvedValue(undefined);
-      mockLSPManager.download.mockResolvedValue(undefined);
-      mockLSPManager.start.mockResolvedValue(undefined);
+      mockLSPManager.update.mockResolvedValue(undefined);
 
       const checker = new StartupChecker(mockLSPManager, mockContext);
 

--- a/src/extension/lsp/__tests__/minisignVerify.test.ts
+++ b/src/extension/lsp/__tests__/minisignVerify.test.ts
@@ -1,7 +1,14 @@
+jest.mock("crypto", () => {
+  const nativeCrypto = jest.requireActual<typeof import("crypto")>("crypto");
+  return { ...nativeCrypto, createHash: jest.fn(nativeCrypto.createHash) };
+});
+
 import * as crypto from "crypto";
 import { verify } from "../minisignVerify";
 
+const nativeCrypto = jest.requireActual<typeof import("crypto")>("crypto");
 const SIG_ALGO = Buffer.from("Ed");
+const PREHASHED_SIG_ALGO = Buffer.from("ED");
 const KEY_ID = Buffer.from("0102030405060708", "hex");
 
 function rawPublicKeyFromKeyObject(key: crypto.KeyObject): Buffer {
@@ -39,6 +46,32 @@ function buildMinisig(
   ].join("\n");
 }
 
+function buildPrehashedMinisig(
+  privateKey: crypto.KeyObject,
+  message: Buffer,
+  trustedComment: string
+): string {
+  const prehashedMessage = crypto.createHash("blake2b512").update(message).digest();
+  const signature = crypto.sign(null, prehashedMessage, privateKey);
+  const globalMsg = Buffer.concat([
+    signature,
+    Buffer.from(trustedComment, "utf-8"),
+  ]);
+  const globalSig = crypto.sign(null, globalMsg, privateKey);
+
+  const sigLine = Buffer.concat([PREHASHED_SIG_ALGO, KEY_ID, signature]).toString(
+    "base64"
+  );
+  const globalSigLine = globalSig.toString("base64");
+
+  return [
+    "untrusted comment: test signature",
+    sigLine,
+    `trusted comment: ${trustedComment}`,
+    globalSigLine,
+  ].join("\n");
+}
+
 describe("minisignVerify", () => {
   let publicKey: crypto.KeyObject;
   let privateKey: crypto.KeyObject;
@@ -56,6 +89,35 @@ describe("minisignVerify", () => {
     const minisig = buildMinisig(privateKey, message, "timestamp:1234\tfile:test");
 
     expect(verify(minisignPk, minisig, message)).toBe(true);
+  });
+
+  it("accepts a valid prehashed ED signature", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildPrehashedMinisig(
+      privateKey,
+      message,
+      "timestamp:1234\tfile:test"
+    );
+
+    expect(verify(minisignPk, minisig, message)).toBe(true);
+  });
+
+  it("accepts valid ED when native blake2b512 is unavailable", () => {
+    const message = Buffer.from("hello world");
+    const minisig = buildPrehashedMinisig(
+      privateKey,
+      message,
+      "timestamp:1234\tfile:test"
+    );
+    const createHashMock = jest.mocked(crypto.createHash).mockImplementation(() => {
+      throw new Error("blake2b512 is unavailable");
+    });
+
+    try {
+      expect(verify(minisignPk, minisig, message)).toBe(true);
+    } finally {
+      createHashMock.mockImplementation(nativeCrypto.createHash);
+    }
   });
 
   it("rejects a signature over a different message", () => {

--- a/src/extension/lsp/minisignVerify.ts
+++ b/src/extension/lsp/minisignVerify.ts
@@ -1,7 +1,9 @@
 import * as crypto from "crypto";
+import { blake2b } from "blakejs";
 
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 const SIG_ALGO = Buffer.from("Ed");
+const PREHASHED_SIG_ALGO = Buffer.from("ED");
 const KEY_ID_LEN = 8;
 const SIG_LEN = 64;
 const PK_LEN = 32;
@@ -20,7 +22,7 @@ function toEd25519KeyObject(rawPk: Buffer): crypto.KeyObject {
  *
  * Minisign uses Ed25519. The .minisig format:
  *   untrusted comment: ...
- *   <base64: 2B algo "Ed" + 8B keyId + 64B signature>
+ *   <base64: 2B algo "Ed" or "ED" + 8B keyId + 64B signature>
  *   trusted comment: ...
  *   <base64: 64B global signature over (signature || trustedComment)>
  *
@@ -55,7 +57,9 @@ export function verify(
 
     const sigRaw = Buffer.from(sigLine, "base64");
     if (sigRaw.length < 2 + KEY_ID_LEN + SIG_LEN) return false;
-    if (!sigRaw.subarray(0, 2).equals(SIG_ALGO)) return false;
+    const signatureAlgorithm = sigRaw.subarray(0, 2);
+    const isPrehashed = signatureAlgorithm.equals(PREHASHED_SIG_ALGO);
+    if (!isPrehashed && !signatureAlgorithm.equals(SIG_ALGO)) return false;
     if (!sigRaw.subarray(2, 2 + KEY_ID_LEN).equals(keyId)) return false;
     const signature = sigRaw.subarray(2 + KEY_ID_LEN, 2 + KEY_ID_LEN + SIG_LEN);
 
@@ -64,7 +68,10 @@ export function verify(
     const globalSig = Buffer.from(globalSigLine, "base64");
     if (globalSig.length !== SIG_LEN) return false;
 
-    if (!crypto.verify(null, Buffer.from(message), publicKey, signature))
+    const signedMessage = isPrehashed
+      ? Buffer.from(blake2b(message, undefined, 64))
+      : Buffer.from(message);
+    if (!crypto.verify(null, signedMessage, publicKey, signature))
       return false;
 
     const globalMsg = Buffer.concat([

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -278,9 +278,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 );
 
                 if (answer === "Update") {
-                  await lspManager.stop();
-                  await lspManager.download(progress);
-                  await lspManager.start();
+                  await lspManager.update(progress);
                   vscode.window.showInformationMessage(
                     `Updated to ${latestVersion}`
                   );


### PR DESCRIPTION
## Purpose

Keep the currently running HLedger LSP available while an update candidate is downloaded and verified. A failed verification must leave the installed server running instead of prompting a pointless restart.

## Changes

- stage and verify the downloaded binary before stopping the running language server
- centralize update, restart, and recovery behavior in `LSPManager`
- support both legacy Minisign `Ed` signatures and prehashed `ED` signatures
- use `blakejs` for BLAKE2b-512 in VS Code runtimes where the native crypto backend does not expose it
- restrict HLedger document selectors to file-backed documents
- add regression coverage for verification failures, safe replacement, restart recovery, signature formats, and selectors

## Verification

- `npm test -- --runInBand` — 742 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm audit --omit=dev` — 0 vulnerabilities
- verified the real `hledger-lsp` v0.2.53 release asset in the Electron runtime used by VS Code

## Code pointers

- `src/extension/lsp/minisignVerify.ts`
- `src/extension/lsp/BinaryManager.ts`
- `src/extension/lsp/LSPManager.ts`
- `src/extension/lsp/StartupChecker.ts`
- `src/extension/lsp/HLedgerLanguageClient.ts`
- `src/extension/main.ts`

Closes #238
