### PR TITLE
fix(inlay-hints): expose inlay hint settings and stop the Tab cursor jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ Import bank statements and transaction data from CSV/TSV files.
   // Inline completions (ghost text)
   "hledger.features.inlineCompletion": true,
 
+  // Inlay hints (rendered inside the line, never saved to the file)
+  "hledger.inlayHints.inferredAmounts": false,  // Show the amount hledger infers for a posting
+  "hledger.inlayHints.runningBalances": false,
+
   // Formatting
   "editor.formatOnType": true,   // Enable on-type formatting (Enter/Tab via LSP)
   "editor.formatOnSave": true,   // Enable auto-formatting on save

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -96,6 +96,26 @@ Quick Navigation:
 5. Ensure not in snippet mode: Ghost text disabled during snippet editing (Tab navigation)
 6. **Ensure Language Server is running:** Inline completions require hledger-lsp. Check with `Ctrl+Shift+P` → "HLedger: Show Language Server Version"
 
+### Cursor Jumps After Pressing Tab
+
+**Symptoms:** Tab moves the cursor to the amount column, then a greyed-out amount such as `= 20.50 USD` appears and the cursor no longer lines up with the amounts above.
+
+**Cause:** That text is an inlay hint showing the amount hledger infers for the posting. Inlay hints are drawn inside the line, so they push everything to their right — including the alignment padding and the cursor. `hledger.features.inlineCompletion` does not control them; it governs ghost text completions, which are a different feature.
+
+**Solutions:**
+
+1. Turn the hints off: `"hledger.inlayHints.inferredAmounts": false` (this is the default)
+2. To write the amount into the file instead, press `Cmd+K =` / `Ctrl+K =` (**HLedger: Insert Inferred Amount**). It aligns the amount to the amount column and works whether or not the hints are shown.
+3. Update the Language Server: `Ctrl+Shift+P` → "HLedger: Install/Update Language Server". Older servers anchor the hint next to the account name, which shifts the cursor the moment the hint appears.
+
+### Feature Settings Have No Effect
+
+**Symptoms:** Toggling a `hledger.features.*` setting changes nothing.
+
+**Cause:** The Language Server registers its capabilities once, during startup.
+
+**Solution:** Accept the "Restart Server" prompt shown after the change, or run `Ctrl+Shift+P` → "HLedger: Restart Language Server". Settings outside `hledger.features.*` — including `hledger.inlayHints.*` — apply immediately.
+
 ---
 
 ## Performance Issues

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -912,7 +912,7 @@ Extension logs are available in the Output panel under **HLedger** channel (`Vie
 | `hledger.lsp.showVersion` | Show installed version and status |
 | `hledger.lsp.restart` | Restart the language server |
 
-> **Note:** CLI commands (`hledger.cli.balance`, `hledger.cli.stats`, `hledger.cli.incomestatement`) and `hledger.editor.alignAmount` only appear in the Command Palette when a `.journal`/`.hledger`/`.ledger` file is active. Import and LSP commands are always available.
+> **Note:** CLI commands (`hledger.cli.balance`, `hledger.cli.stats`, `hledger.cli.incomestatement`), `hledger.editor.alignAmount` and `hledger.editor.insertInferredAmount` only appear in the Command Palette when a `.journal`/`.hledger`/`.ledger` file is active. Import and LSP commands are always available.
 
 ### LSP Settings
 
@@ -939,6 +939,7 @@ Control which Language Server features are enabled:
 | `hledger.features.workspaceSymbol` | boolean | `true` | Enable workspace symbol search |
 | `hledger.features.inlineCompletion` | boolean | `true` | Enable inline ghost text completions |
 | `hledger.features.codeLens` | boolean | `false` | Enable balance check indicators on transactions |
+| `hledger.features.inlayHints` | boolean | `true` | Enable inlay hints (requires a server restart) |
 
 ### LSP Completion Settings
 
@@ -1027,6 +1028,19 @@ Auto-download supports:
 |---------|------|---------|-------------|
 | `hledger.features.inlineCompletion` | boolean | `true` | Enable ghost text completions |
 
+### Inlay Hint Settings
+
+Inlay hints are read-only annotations the Language Server renders inside the line. They are not part of the file and are never saved.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `hledger.features.inlayHints` | boolean | `true` | Enable inlay hints (requires a server restart) |
+| `hledger.inlayHints.inferredAmounts` | boolean | `false` | Show the amount hledger infers for a posting left without one |
+| `hledger.inlayHints.runningBalances` | boolean | `false` | Show the running account balance after each posting |
+| `hledger.inlayHints.costExpansion` | boolean | `false` | Show the total cost of postings that carry a per-unit price |
+
+Inferred amount hints are off by default. A hint takes up room in the rendered line, so while you are typing an amount it shifts the rest of the line to the right. To write the inferred amount into the file instead, use **HLedger: Insert Inferred Amount** (`Cmd+K =` / `Ctrl+K =`), which works whether or not the hints are shown.
+
 ### CLI Integration Settings
 
 | Setting | Type | Default | Description |
@@ -1103,6 +1117,7 @@ The `amountAlignmentTarget` setting applies to postings that carry cost notation
 | `hledger.features.workspaceSymbol` | boolean | `true` | Enable workspace symbol search |
 | `hledger.features.inlineCompletion` | boolean | `true` | Enable inline ghost text completions |
 | `hledger.features.codeLens` | boolean | `false` | Enable balance check indicators on transactions |
+| `hledger.features.inlayHints` | boolean | `true` | Enable inlay hints (requires a server restart) |
 
 ### LSP Completion Settings
 
@@ -1163,6 +1178,7 @@ All commands accessible via Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`):
 | `hledger.lsp.showVersion` | HLedger: Show Language Server Version | Show LSP version info |
 | `hledger.lsp.restart` | HLedger: Restart Language Server | Restart the LSP server |
 | `hledger.editor.alignAmount` | HLedger: Align Amount to Column | Align amount at cursor via LSP |
+| `hledger.editor.insertInferredAmount` | HLedger: Insert Inferred Amount | Write the inferred balancing amount at the amount column |
 | `hledger.editor.cycleStatus` | HLedger: Cycle Transaction/Posting Status | Cycle status: unmarked → ! → * → unmarked |
 | `hledger.editor.setStatusUnmarked` | HLedger: Set Status to Unmarked | Remove status marker |
 | `hledger.editor.setStatusPending` | HLedger: Set Status to Pending (!) | Set pending status |
@@ -1180,6 +1196,7 @@ All commands accessible via Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`):
 | `Enter` | Accept completion | When completion widget is visible |
 | `Enter` | Accept inline suggestion | When ghost text is visible |
 | `Tab` | Align amount to column | When no suggestions/snippets active |
+| `Cmd+K =` / `Ctrl+K =` | Insert inferred amount | On a posting hledger can infer an amount for |
 | `Cmd+K S` / `Ctrl+K S` | Cycle transaction/posting status | In hledger files |
 | `Cmd+K 0` / `Ctrl+K 0` | Set status to unmarked | In hledger files |
 | `Cmd+K 1` / `Ctrl+K 1` | Set status to pending (!) | In hledger files |

--- a/package.json
+++ b/package.json
@@ -248,6 +248,26 @@
           "default": false,
           "description": "Enable balance check indicators on transactions (CodeLens)"
         },
+        "hledger.features.inlayHints": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable inlay hints from the Language Server (requires a server restart to take effect)"
+        },
+        "hledger.inlayHints.inferredAmounts": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the amount hledger infers for a posting left without one. The hint renders inside the posting line, so it shifts the amount column while you type."
+        },
+        "hledger.inlayHints.runningBalances": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the running account balance after each posting"
+        },
+        "hledger.inlayHints.costExpansion": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the total cost of postings that carry a per-unit price"
+        },
         "hledger.keybindings.enterAndSuggest": {
           "type": "boolean",
           "default": true,
@@ -257,6 +277,11 @@
           "type": "boolean",
           "default": true,
           "description": "Rebind Tab in hledger files to align amounts via the Language Server (disable to restore default VS Code Tab behavior)"
+        },
+        "hledger.keybindings.insertInferredAmount": {
+          "type": "boolean",
+          "default": true,
+          "description": "Bind Cmd+K = (Ctrl+K = on Windows/Linux) in hledger files to insert the inferred balancing amount at the amount column"
         },
         "hledger.completion.snippets": {
           "type": "boolean",
@@ -463,6 +488,11 @@
         "category": "HLedger"
       },
       {
+        "command": "hledger.editor.insertInferredAmount",
+        "title": "HLedger: Insert Inferred Amount",
+        "category": "HLedger"
+      },
+      {
         "command": "hledger.editor.enterAndSuggest",
         "title": "HLedger: Enter and Suggest Inline Completion",
         "category": "HLedger"
@@ -517,6 +547,14 @@
         "command": "hledger.editor.alignAmount",
         "key": "tab",
         "when": "editorTextFocus && editorLangId == hledger && !suggestWidgetVisible && !inlineSuggestionVisible && !inSnippetMode && !hasSnippetCompletions && config.hledger.keybindings.alignAmount"
+      },
+      {
+        "command": "hledger.editor.insertInferredAmount",
+        "key": "ctrl+k =",
+        "mac": "cmd+k =",
+        "win": "ctrl+k =",
+        "linux": "ctrl+k =",
+        "when": "editorTextFocus && editorLangId == hledger && config.hledger.keybindings.insertInferredAmount"
       },
       {
         "command": "hledger.editor.cycleStatus",
@@ -606,6 +644,10 @@
         },
         {
           "command": "hledger.editor.alignAmount",
+          "when": "editorLangId == hledger"
+        },
+        {
+          "command": "hledger.editor.insertInferredAmount",
           "when": "editorLangId == hledger"
         }
       ]

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -495,23 +495,21 @@ export class Selection extends Range {
     activeLine?: number,
     activeCharacter?: number,
   ) {
-    if (typeof anchorOrLine === "number") {
-      super(
-        anchorOrLine,
-        anchorCharacterOrActive as number,
-        activeLine!,
-        activeCharacter!,
-      );
-      this.anchor = new Position(
-        anchorOrLine,
-        anchorCharacterOrActive as number,
-      );
-      this.active = new Position(activeLine!, activeCharacter!);
-    } else {
-      super(anchorOrLine, anchorCharacterOrActive as Position);
-      this.anchor = anchorOrLine;
-      this.active = anchorCharacterOrActive as Position;
-    }
+    // super() must be the first statement: with useDefineForClassFields the
+    // class fields below are emitted right after it, and calling it from
+    // inside a branch makes them run before the base constructor.
+    const anchor =
+      typeof anchorOrLine === "number"
+        ? new Position(anchorOrLine, anchorCharacterOrActive as number)
+        : anchorOrLine;
+    const active =
+      typeof anchorOrLine === "number"
+        ? new Position(activeLine!, activeCharacter!)
+        : (anchorCharacterOrActive as Position);
+
+    super(anchor, active);
+    this.anchor = anchor;
+    this.active = active;
   }
 
   get isReversed(): boolean {

--- a/src/extension/__tests__/keybindings.test.ts
+++ b/src/extension/__tests__/keybindings.test.ts
@@ -63,6 +63,21 @@ describe('keybinding contributions', () => {
     expect(alignKeybinding?.when).toContain('!inlineSuggestionVisible');
   });
 
+  it('binds the inferred amount command behind its own toggle', () => {
+    const keybinding = getKeybinding('hledger.editor.insertInferredAmount');
+
+    expect(keybinding?.key).toBe('ctrl+k =');
+    expect(keybinding?.when).toContain('editorLangId == hledger');
+    expect(keybinding?.when).toContain(
+      'config.hledger.keybindings.insertInferredAmount'
+    );
+    expect(
+      pkg.contributes?.configuration?.properties?.[
+        'hledger.keybindings.insertInferredAmount'
+      ]?.default
+    ).toBe(true);
+  });
+
   it('keeps transaction status keybindings active in hledger editors', () => {
     const statusCommands = new Set([
       'hledger.editor.cycleStatus',

--- a/src/extension/commands/__tests__/insertInferredAmount.test.ts
+++ b/src/extension/commands/__tests__/insertInferredAmount.test.ts
@@ -1,0 +1,148 @@
+import * as vscode from "vscode";
+import { insertInferredAmount } from "../insertInferredAmount";
+
+interface MockLSPClient {
+  sendRequest: jest.Mock;
+}
+
+const ACTION = {
+  title: "Insert inferred amount (20.50 USD)",
+  kind: "quickfix.hledger.insertInferredAmount",
+  edit: {
+    changes: {
+      "file:///test.journal": [
+        {
+          range: {
+            start: { line: 2, character: 17 },
+            end: { line: 2, character: 17 },
+          },
+          newText: "   20.50 USD",
+        },
+      ],
+    },
+  },
+};
+
+describe("insertInferredAmount", () => {
+  let mockClient: MockLSPClient;
+  let applyEditMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockClient = { sendRequest: jest.fn() };
+
+    applyEditMock = jest.fn().mockResolvedValue(true);
+    (vscode.workspace as any).applyEdit = applyEditMock;
+
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        uri: { toString: () => "file:///test.journal" },
+        languageId: "hledger",
+      },
+      selection: { active: new vscode.Position(2, 17) },
+    };
+  });
+
+  it("asks the server for the inferred amount action at the cursor", async () => {
+    mockClient.sendRequest.mockResolvedValue([ACTION]);
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(mockClient.sendRequest).toHaveBeenCalledWith(
+      "textDocument/codeAction",
+      expect.objectContaining({
+        textDocument: { uri: "file:///test.journal" },
+        range: {
+          start: { line: 2, character: 17 },
+          end: { line: 2, character: 17 },
+        },
+        context: {
+          diagnostics: [],
+          only: ["quickfix.hledger.insertInferredAmount"],
+        },
+      }),
+    );
+    expect(applyEditMock).toHaveBeenCalled();
+  });
+
+  it("ignores actions of other kinds", async () => {
+    mockClient.sendRequest.mockResolvedValue([
+      { ...ACTION, kind: "quickfix", title: "Fix final posting amount" },
+    ]);
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("applies the edit even when the server keys it by a differently encoded uri", async () => {
+    mockClient.sendRequest.mockResolvedValue([
+      {
+        ...ACTION,
+        edit: { changes: { "file:///test%2Ejournal": ACTION.edit.changes["file:///test.journal"] } },
+      },
+    ]);
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(applyEditMock).toHaveBeenCalled();
+  });
+
+  it("does nothing when the server offers no action", async () => {
+    mockClient.sendRequest.mockResolvedValue([]);
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the request times out", async () => {
+    mockClient.sendRequest.mockImplementation(() => new Promise(() => {}));
+
+    await insertInferredAmount(() => mockClient, 10);
+
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the request fails", async () => {
+    mockClient.sendRequest.mockRejectedValue(new Error("server gone"));
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without an LSP client", async () => {
+    await insertInferredAmount(() => null);
+
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing in a non-hledger document", async () => {
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        uri: { toString: () => "file:///notes.md" },
+        languageId: "markdown",
+      },
+      selection: { active: new vscode.Position(0, 0) },
+    };
+    mockClient.sendRequest.mockResolvedValue([ACTION]);
+
+    await insertInferredAmount(() => mockClient);
+
+    expect(mockClient.sendRequest).not.toHaveBeenCalled();
+    expect(applyEditMock).not.toHaveBeenCalled();
+  });
+
+  it("moves the cursor past the inserted amount", async () => {
+    mockClient.sendRequest.mockResolvedValue([ACTION]);
+
+    await insertInferredAmount(() => mockClient);
+
+    const editor = vscode.window.activeTextEditor as unknown as {
+      selection: vscode.Selection;
+    };
+    expect(editor.selection.active.line).toBe(2);
+    expect(editor.selection.active.character).toBe(17 + "   20.50 USD".length);
+  });
+});

--- a/src/extension/commands/insertInferredAmount.ts
+++ b/src/extension/commands/insertInferredAmount.ts
@@ -1,0 +1,130 @@
+import * as vscode from "vscode";
+
+interface LSPClient {
+  sendRequest<R>(method: string, params?: unknown): Promise<R>;
+}
+
+interface LSPTextEdit {
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  newText: string;
+}
+
+interface LSPCodeAction {
+  title?: string;
+  kind?: string;
+  edit?: {
+    changes?: Record<string, LSPTextEdit[]>;
+  };
+}
+
+/** Kind the Language Server tags the inferred-amount action with. */
+const INFERRED_AMOUNT_KIND = "quickfix.hledger.insertInferredAmount";
+
+const DEFAULT_TIMEOUT_MS = 600;
+
+function requestWithTimeout(
+  client: LSPClient,
+  params: unknown,
+  timeoutMs: number,
+): Promise<LSPCodeAction[] | null | undefined> {
+  return new Promise((resolve) => {
+    let resolved = false;
+
+    const timeoutId = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        resolve(undefined);
+      }
+    }, timeoutMs);
+
+    client
+      .sendRequest<LSPCodeAction[] | null>("textDocument/codeAction", params)
+      .then((result) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeoutId);
+          resolve(result);
+        }
+      })
+      .catch(() => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeoutId);
+          resolve(undefined);
+        }
+      });
+  });
+}
+
+/**
+ * Writes the amount hledger infers for the posting under the cursor into the
+ * document, aligned to the amount column. Silent when there is nothing to
+ * infer — it is bound to a key, so a message on every miss would be noise.
+ */
+export async function insertInferredAmount(
+  getClient: () => LSPClient | null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (editor?.document.languageId !== "hledger") {
+    return;
+  }
+
+  const client = getClient();
+  if (!client) {
+    return;
+  }
+
+  const { document, selection } = editor;
+  const position = selection.active;
+  const cursor = { line: position.line, character: position.character };
+
+  const actions = await requestWithTimeout(
+    client,
+    {
+      textDocument: { uri: document.uri.toString() },
+      range: { start: cursor, end: cursor },
+      context: { diagnostics: [], only: [INFERRED_AMOUNT_KIND] },
+    },
+    timeoutMs,
+  );
+
+  const action = actions?.find((candidate) => candidate.kind === INFERRED_AMOUNT_KIND);
+  const changes = action?.edit?.changes;
+  // The server keys the edit by the URI it was handed, but normalization on
+  // either side can still make the strings differ; the action only ever edits
+  // the document it was requested for, so fall back to the single entry.
+  const edits =
+    changes?.[document.uri.toString()] ?? Object.values(changes ?? {})[0];
+  if (!edits || edits.length === 0) {
+    return;
+  }
+
+  const workspaceEdit = new vscode.WorkspaceEdit();
+  for (const edit of edits) {
+    workspaceEdit.replace(
+      document.uri,
+      new vscode.Range(
+        edit.range.start.line,
+        edit.range.start.character,
+        edit.range.end.line,
+        edit.range.end.character,
+      ),
+      edit.newText,
+    );
+  }
+
+  if (!(await vscode.workspace.applyEdit(workspaceEdit))) {
+    return;
+  }
+
+  const lastEdit = edits[edits.length - 1];
+  if (lastEdit) {
+    const line = lastEdit.range.start.line;
+    const character = lastEdit.range.start.character + lastEdit.newText.length;
+    editor.selection = new vscode.Selection(line, character, line, character);
+  }
+}

--- a/src/extension/lsp/HLedgerLanguageClient.ts
+++ b/src/extension/lsp/HLedgerLanguageClient.ts
@@ -91,6 +91,12 @@ function getVSCodeSettings(): VSCodeSettings {
       workspaceSymbol: config.get<boolean>("features.workspaceSymbol"),
       inlineCompletion: config.get<boolean>("features.inlineCompletion"),
       codeLens: config.get<boolean>("features.codeLens"),
+      inlayHints: config.get<boolean>("features.inlayHints"),
+    },
+    inlayHints: {
+      inferredAmounts: config.get<boolean>("inlayHints.inferredAmounts"),
+      runningBalances: config.get<boolean>("inlayHints.runningBalances"),
+      costExpansion: config.get<boolean>("inlayHints.costExpansion"),
     },
     autoCompletion: {
       enabled: config.get<boolean>("autoCompletion.enabled"),

--- a/src/extension/lsp/__tests__/featureRestartPrompt.test.ts
+++ b/src/extension/lsp/__tests__/featureRestartPrompt.test.ts
@@ -1,0 +1,67 @@
+import * as vscode from "vscode";
+import { registerFeatureRestartPrompt } from "../featureRestartPrompt";
+
+type ConfigurationListener = (
+  event: vscode.ConfigurationChangeEvent,
+) => unknown;
+
+function captureListener(): ConfigurationListener {
+  const mock = vscode.workspace.onDidChangeConfiguration as unknown as jest.Mock;
+  const listener = mock.mock.calls[mock.mock.calls.length - 1]?.[0];
+  expect(listener).toBeDefined();
+  return listener as ConfigurationListener;
+}
+
+function changeEvent(changed: string): vscode.ConfigurationChangeEvent {
+  return {
+    affectsConfiguration: (section: string) => section === changed,
+  } as vscode.ConfigurationChangeEvent;
+}
+
+describe("registerFeatureRestartPrompt", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("offers a restart when a feature toggle changes", async () => {
+    (vscode.window.showInformationMessage as unknown as jest.Mock).mockResolvedValue(
+      "Restart Server",
+    );
+
+    registerFeatureRestartPrompt();
+    await captureListener()(changeEvent("hledger.features"));
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Restart the Language Server"),
+      "Restart Server",
+    );
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      "hledger.lsp.restart",
+    );
+  });
+
+  it("leaves the server alone when the prompt is dismissed", async () => {
+    (vscode.window.showInformationMessage as unknown as jest.Mock).mockResolvedValue(
+      undefined,
+    );
+
+    registerFeatureRestartPrompt();
+    await captureListener()(changeEvent("hledger.features"));
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it("ignores settings that reach the server without a restart", async () => {
+    registerFeatureRestartPrompt();
+    await captureListener()(changeEvent("hledger.inlayHints"));
+
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns a disposable listener", () => {
+    const disposable = registerFeatureRestartPrompt();
+
+    expect(typeof disposable.dispose).toBe("function");
+  });
+});

--- a/src/extension/lsp/__tests__/settingsMapper.test.ts
+++ b/src/extension/lsp/__tests__/settingsMapper.test.ts
@@ -21,6 +21,12 @@ describe("mapVSCodeSettingsToLSP", () => {
           workspaceSymbol: true,
           inlineCompletion: true,
           codeLens: false,
+          inlayHints: true,
+        },
+        inlayHints: {
+          inferredAmounts: false,
+          runningBalances: false,
+          costExpansion: false,
         },
         completion: {
           maxResults: 50,
@@ -70,6 +76,7 @@ describe("mapVSCodeSettingsToLSP", () => {
           workspaceSymbol: false,
           inlineCompletion: false,
           codeLens: false,
+          inlayHints: false,
         },
       };
 
@@ -87,6 +94,7 @@ describe("mapVSCodeSettingsToLSP", () => {
         workspaceSymbol: false,
         inlineCompletion: false,
         codeLens: false,
+        inlayHints: false,
       });
     });
 
@@ -139,6 +147,40 @@ describe("mapVSCodeSettingsToLSP", () => {
       const result = mapVSCodeSettingsToLSP(settings);
 
       expect(result.features.codeLens).toBe(true);
+    });
+
+    it("maps features.inlayHints when set to false", () => {
+      const settings: VSCodeSettings = {
+        features: { inlayHints: false },
+      };
+
+      const result = mapVSCodeSettingsToLSP(settings);
+
+      expect(result.features.inlayHints).toBe(false);
+    });
+  });
+
+  describe("inlay hint settings", () => {
+    it("keeps inferred amount hints off unless asked for", () => {
+      expect(mapVSCodeSettingsToLSP({}).inlayHints.inferredAmounts).toBe(false);
+    });
+
+    it("maps every inlay hint category", () => {
+      const settings: VSCodeSettings = {
+        inlayHints: {
+          inferredAmounts: true,
+          runningBalances: true,
+          costExpansion: true,
+        },
+      };
+
+      const result = mapVSCodeSettingsToLSP(settings);
+
+      expect(result.inlayHints).toEqual({
+        inferredAmounts: true,
+        runningBalances: true,
+        costExpansion: true,
+      });
     });
   });
 

--- a/src/extension/lsp/featureRestartPrompt.ts
+++ b/src/extension/lsp/featureRestartPrompt.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode";
+
+const RESTART_ACTION = "Restart Server";
+
+/**
+ * The Language Server decides which capabilities to register during the
+ * initialize handshake, so a `hledger.features.*` toggle only takes effect
+ * after a restart. Everything else under `hledger.*` is re-read by the server
+ * on configuration change and needs no prompt.
+ */
+export function registerFeatureRestartPrompt(): vscode.Disposable {
+  return vscode.workspace.onDidChangeConfiguration(async (event) => {
+    if (!event.affectsConfiguration("hledger.features")) {
+      return;
+    }
+
+    const action = await vscode.window.showInformationMessage(
+      "HLedger feature settings changed. Restart the Language Server to apply them.",
+      RESTART_ACTION,
+    );
+    if (action === RESTART_ACTION) {
+      await vscode.commands.executeCommand("hledger.lsp.restart");
+    }
+  });
+}

--- a/src/extension/lsp/settingsMapper.ts
+++ b/src/extension/lsp/settingsMapper.ts
@@ -11,6 +11,12 @@ export interface VSCodeSettings {
     workspaceSymbol?: boolean;
     inlineCompletion?: boolean;
     codeLens?: boolean;
+    inlayHints?: boolean;
+  };
+  inlayHints?: {
+    inferredAmounts?: boolean;
+    runningBalances?: boolean;
+    costExpansion?: boolean;
   };
   autoCompletion?: {
     enabled?: boolean;
@@ -42,9 +48,6 @@ export interface VSCodeSettings {
     amountAlignmentMode?: "left" | "right" | "decimal";
     minAlignmentColumn?: number;
     amountAlignmentTarget?: "cost" | "posting";
-  };
-  inlineCompletion?: {
-    enabled?: boolean;
   };
   cli?: {
     path?: string;
@@ -79,6 +82,12 @@ export interface LSPSettings {
     workspaceSymbol: boolean;
     inlineCompletion: boolean;
     codeLens: boolean;
+    inlayHints: boolean;
+  };
+  inlayHints: {
+    inferredAmounts: boolean;
+    runningBalances: boolean;
+    costExpansion: boolean;
   };
   completion: {
     maxResults: number;
@@ -124,6 +133,14 @@ const DEFAULT_SETTINGS: LSPSettings = {
     workspaceSymbol: true,
     inlineCompletion: true,
     codeLens: false,
+    inlayHints: true,
+  },
+  // Inferred amount hints are opt-in: they render inside the posting line, so
+  // they shift the amount column of the line being edited.
+  inlayHints: {
+    inferredAmounts: false,
+    runningBalances: false,
+    costExpansion: false,
   },
   completion: {
     maxResults: 50,
@@ -223,6 +240,12 @@ export function mapVSCodeSettingsToLSP(settings: VSCodeSettings): LSPSettings {
       workspaceSymbol: settings.features?.workspaceSymbol ?? DEFAULT_SETTINGS.features.workspaceSymbol,
       inlineCompletion: settings.features?.inlineCompletion ?? DEFAULT_SETTINGS.features.inlineCompletion,
       codeLens: settings.features?.codeLens ?? DEFAULT_SETTINGS.features.codeLens,
+      inlayHints: settings.features?.inlayHints ?? DEFAULT_SETTINGS.features.inlayHints,
+    },
+    inlayHints: {
+      inferredAmounts: settings.inlayHints?.inferredAmounts ?? DEFAULT_SETTINGS.inlayHints.inferredAmounts,
+      runningBalances: settings.inlayHints?.runningBalances ?? DEFAULT_SETTINGS.inlayHints.runningBalances,
+      costExpansion: settings.inlayHints?.costExpansion ?? DEFAULT_SETTINGS.inlayHints.costExpansion,
     },
     completion: {
       maxResults: validateNumber(

--- a/src/extension/main.ts
+++ b/src/extension/main.ts
@@ -5,8 +5,10 @@ import { HLedgerCliCommands } from "./HLedgerCliCommands";
 import { HLedgerCliService } from "./services/HLedgerCliService";
 import { HLedgerImportCommands } from "./HLedgerImportCommands";
 import { LSPManager, StartupChecker } from "./lsp";
+import { registerFeatureRestartPrompt } from "./lsp/featureRestartPrompt";
 import { alignAmount } from "./commands/alignAmount";
 import { enterAndSuggest } from "./commands/enterAndSuggest";
+import { insertInferredAmount } from "./commands/insertInferredAmount";
 import { cycleStatus, setStatus } from "./commands/toggleStatus";
 import { InlineCompletionProvider } from "./inline/InlineCompletionProvider";
 import { KeybindingHintsStatusBar } from "./KeybindingHintsStatusBar";
@@ -34,6 +36,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(keybindingHints);
 
     const startupChecker = new StartupChecker(lspManager, context);
+
+    context.subscriptions.push(registerFeatureRestartPrompt());
 
     // Consolidated LSP initialization (non-blocking)
     void (async (): Promise<void> => {
@@ -206,6 +210,15 @@ export function activate(context: vscode.ExtensionContext): void {
         "hledger.editor.alignAmount",
         async () => {
           await alignAmount(() => lspManager.getLanguageClient());
+        },
+      ),
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "hledger.editor.insertInferredAmount",
+        async () => {
+          await insertInferredAmount(() => lspManager.getLanguageClient());
         },
       ),
     );


### PR DESCRIPTION
Closes #245.

## What was actually happening

The greyed-out `= 20.50 USD` that displaces the cursor after Tab is an **inlay hint** from the Language Server, not an inline completion. VS Code renders inlay hints inside the line, so the hint pushed the alignment padding — and the cursor sitting at the amount column — to the right, exactly while the user was about to type an amount.

That also explains the follow-up report that turning off inline ghost text changed nothing: `hledger.features.inlineCompletion` governs a different feature, and the extension forwarded no inlay hint settings at all (`grep -ri inlayhint` over the repo returned nothing), while the server enables them by default. There was no way to turn the hint off short of VS Code's global `editor.inlayHints.enabled`.

## Changes

**Inlay hint settings are forwarded.** New: `hledger.features.inlayHints`, `hledger.inlayHints.inferredAmounts`, `hledger.inlayHints.runningBalances`, `hledger.inlayHints.costExpansion`. Inferred amount hints default to **off** — the hint renders inside the posting line, so it shifts the amount column precisely while an amount is being typed. The other categories default to off as well; the feature flag defaults to on.

**New command `hledger.editor.insertInferredAmount` (`Cmd+K =` / `Ctrl+K =`)**, which is what the issue author asked for. It requests the server's `quickfix.hledger.insertInferredAmount` action and writes the inferred balancing amount at the amount column. It does not depend on the hint settings, so it works with the hints off. The keybinding sits behind `hledger.keybindings.insertInferredAmount`, like the existing Enter and Tab overrides.

**Restart prompt for feature toggles.** The server registers its capabilities during the initialize handshake, so a `hledger.features.*` change only takes effect after a restart. Changing one now offers to restart the server. Everything outside `hledger.features.*`, including `hledger.inlayHints.*`, still applies immediately.

**Mock fix.** `Selection` in the VS Code mock threw on construction: with `useDefineForClassFields` its class fields were emitted before the conditional `super()` call, so no test could cover a command that moves the cursor.

Docs updated: settings tables and the new command/keybinding in `docs/user-guide.md`, essential settings in `README.md`, and two entries in `TROUBLESHOOTING.md` — one for the cursor jump, one for feature settings appearing to do nothing.

## Requires

The server-side half is juev/hledger-lsp#71. The hint anchor fix and the code action the new command calls live there, so this needs the release that follows it.

## Verification

`npm test` (759 tests), `npm run lint`, `npx tsc --noEmit` and `npm run build` all pass.

The server behaviour was checked against a built binary over the LSP wire: the inlay hint now sits at the end of the padded line rather than next to the account name, and the code action edit puts the amount on the same column as the sibling posting.
