### PR TITLE
chore(deps): bump fast-uri from 3.1.4 to 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5168,9 +5168,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Bumps the transitive dev dependency `fast-uri` from 3.1.4 to 3.1.5.

## Why

[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (high) — host confusion via backslash authority introducer. Fixed in 3.1.5 for the 3.x line.

Dependabot flagged this alert but did not open a PR for it.

## Dependency path

```
@vscode/vsce@3.9.2
  -> @secretlint/node@10.2.2
     -> ajv@8.18.0
        -> fast-uri@3.1.4
```

(also reached via `@secretlint/formatter -> table -> ajv`, same deduped instance)

`ajv` declares `fast-uri: ^3.0.1`, so 3.1.5 satisfies the existing range — no `ajv` or `vsce` bump required.

## Scope

Lockfile only, `dev: true`. The package is used during build and packaging and is not shipped in the VSIX, so this needs no extension release on its own.

`npm audit` after the change reports `found 0 vulnerabilities`.
