### PR TITLE
chore(test): restore strict type checking for test sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,19 +24,28 @@ VS Code extension for hledger plain text accounting. Supported file extensions: 
 ```bash
 npm run build          # Production build with esbuild
 npm run watch          # Watch mode with esbuild
-npm run test           # Run all Vitest tests
-npm run test:watch     # Tests in watch mode
-npm run test:coverage  # Tests with coverage report
+npm run test           # Type-check the tests, then run them
+npm run test:watch     # Tests in watch mode (no type check)
+npm run test:coverage  # Tests with coverage report (no type check)
 npm run lint           # ESLint check
 npm run lint:fix       # ESLint with auto-fix
 npm run package        # Create VSIX for distribution
 npx tsc --noEmit       # TypeScript strict type check (run before committing)
-npm run typecheck:test # Type-check the test sources (esbuild does not)
+npm run typecheck:test # Type-check the test sources on their own
 ```
 
 **Important:** Vitest transforms tests with esbuild, which strips types without
-checking them. A type error in a test no longer fails the run, so
-`npm run typecheck:test` is what catches it — CI runs it alongside lint.
+checking them, so a type error in a test cannot fail the test run itself. Only
+`tsc` catches it. Two places do:
+
+- `npm test` runs `typecheck:test` first, via a `pretest` script. This is what
+  keeps a type error from reaching CI — the failure shows up locally instead.
+- CI runs `typecheck:test` as its own step. That step is the guarantee; it stays
+  even though `npm test` would repeat it, so removing `pretest` cannot silently
+  drop the check.
+
+`test:watch` and `test:coverage` deliberately skip it — those are the fast inner
+loop. `npx vitest run <file>` skips it too. Run `npm test` before pushing.
 
 ### Running Single Tests
 
@@ -133,6 +142,7 @@ The extension's `InlineCompletionProvider` handles ghost text completions for tr
 - Vitest with globals enabled (`describe`/`it`/`expect`/`vi` need no import); config in `vitest.config.mts`
 - VS Code is mocked in `src/__mocks__/vscode.ts`, wired through `test.alias` — a CJS `require("vscode")` bypasses that alias, so always import it
 - Mocked classes must use `function` expressions, not arrow functions: Vitest calls them with `new`
+- `tsconfig.test.json` inherits full strictness from `tsconfig.json`; it overrides only how tests are run (ESM, Vitest globals), never how strictly they are checked. Reading a recorded call needs a guard: `mock.mock.calls[0]` is possibly `undefined`
 - Grammar tests use `vscode-textmate` and `vscode-oniguruma` for accurate scope testing
 - `rules-grammar-snapshot.test.ts` detects unintended grammar changes
 

--- a/package.json
+++ b/package.json
@@ -731,6 +731,7 @@
     "typecheck": "tsc --noEmit -p ./",
     "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "watch": "npm run esbuild:watch",
+    "pretest": "npm run typecheck:test",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/extension/commands/__tests__/toggleStatus.test.ts
+++ b/src/extension/commands/__tests__/toggleStatus.test.ts
@@ -12,6 +12,22 @@ import {
   type StatusInfo,
 } from "../toggleStatus";
 
+type EditBuilder = { replace: Mock };
+
+/**
+ * Invokes the callback that the code under test passed to `editor.edit`.
+ *
+ * Reads the recorded call defensively so a missing one fails as a named
+ * assertion rather than "undefined is not a function" several frames away.
+ */
+function applyEdit(editMock: Mock, builder: EditBuilder): void {
+  const call = editMock.mock.calls[0];
+  if (!call) {
+    throw new Error("expected editor.edit to have been called");
+  }
+  (call[0] as (builder: EditBuilder) => void)(builder);
+}
+
 describe("isTransactionHeader", () => {
   it("matches standard date format YYYY-MM-DD", () => {
     expect(isTransactionHeader("2024-01-15 Grocery Store")).toBe(true);
@@ -577,7 +593,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 11),
       "! ",
@@ -589,7 +605,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 13),
       "* ",
@@ -601,7 +617,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 13),
       "",
@@ -612,7 +628,7 @@ describe("cycleStatus", () => {
     setupEditor("2024-01-15 !");
     await cycleStatus();
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 12),
       "* ",
@@ -646,7 +662,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
 
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledTimes(2);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 11),
@@ -663,7 +679,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(1, 4, 1, 4),
       "! ",
@@ -675,7 +691,7 @@ describe("cycleStatus", () => {
     await cycleStatus();
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(2, 4, 2, 6),
       "",
@@ -735,7 +751,7 @@ describe("setStatus", () => {
     await setStatus("*");
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 11),
       "* ",
@@ -747,7 +763,7 @@ describe("setStatus", () => {
     await setStatus("");
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 13),
       "",
@@ -765,7 +781,7 @@ describe("setStatus", () => {
     await setStatus("*");
     expect(editMock).toHaveBeenCalledTimes(1);
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(1, 4, 1, 4),
       "* ",
@@ -799,7 +815,7 @@ describe("setStatus", () => {
     await setStatus("*");
 
     const builder = { replace: vi.fn() };
-    editMock.mock.calls[0][0](builder);
+    applyEdit(editMock, builder);
     expect(builder.replace).toHaveBeenCalledTimes(2);
     expect(builder.replace).toHaveBeenCalledWith(
       new vscode.Range(0, 11, 0, 11),

--- a/src/extension/lsp/__tests__/BinaryManager.test.ts
+++ b/src/extension/lsp/__tests__/BinaryManager.test.ts
@@ -1170,8 +1170,7 @@ describe("BinaryManager", () => {
       manager = new BinaryManager(tempDir, mockFetch);
       await manager.getLatestRelease();
 
-      const callInit = mockFetch.mock.calls[0][1];
-      expect(callInit.signal).toBeInstanceOf(AbortSignal);
+      expect(mockFetch.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
     });
   });
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,40 +1,27 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    // Relax exactOptionalPropertyTypes for tests to allow VSCode mock compatibility
-    "exactOptionalPropertyTypes": false,
-    
-    // Relax strict null checks for tests to handle regex match results.
-    // strictPropertyInitialization must go with it: TS5052 forbids enabling it
-    // (inherited from the base config via "strict") without strictNullChecks.
-    "strictNullChecks": false,
-    "strictPropertyInitialization": false,
-    
-    // Allow unchecked indexed access for test environment
-    "noUncheckedIndexedAccess": false,
-    
-    // Allow implicit any for test environment
-    "noImplicitAny": false,
-    
-    // Allow implicit returns for test mocks
-    "noImplicitReturns": false,
-    
+    // Strictness is inherited from tsconfig.json and deliberately not relaxed:
+    // tests are the only consumer of the hand-written vscode mock, so they are
+    // where its type errors surface first. Only the settings below differ, and
+    // each is about how tests are *run*, not how strictly they are checked.
+
     // Enable types needed for Vitest globals
     "types": ["vitest/globals", "node"],
-    
+
     // Allow importing JSON files for test data
     "resolveJsonModule": true,
-    
+
     // Vitest executes test files as ESM, so top-level await is available here
     // even though the bundled extension itself is emitted as CommonJS.
     "module": "esnext",
 
     // Ensure proper module resolution for test environment
     "moduleResolution": "node",
-    
+
     // Allow synthetic default imports for the hand-written vscode mock
     "allowSyntheticDefaultImports": true,
-    
+
     // Disable noUnusedLocals and noUnusedParameters for test files
     // as tests often have setup code that may appear unused
     "noUnusedLocals": false,


### PR DESCRIPTION
Closes #254

Test sources are now type-checked at the same strictness as the rest of the codebase, and that check runs locally instead of only on GitHub.

## Strictness

`tsconfig.test.json` disabled five flags the rest of the project enforces: `strictNullChecks`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noImplicitAny`, `noImplicitReturns` (plus `strictPropertyInitialization`, which TS5052 forces along with `strictNullChecks`). All six are gone; the file now overrides only how tests are *run* — ESM for top-level await, Vitest globals, module resolution.

The whole cost was **12 errors in 2 files**, all the same idiom: reading a mock's recorded call without checking it exists.

Worth knowing for anyone auditing similar configs: these flags only mean anything **together**. `noUncheckedIndexedAccess` is inert while `strictNullChecks` is off, so enabling them one at a time reports almost nothing and looks like there is no debt.

## The 12 fixes

`toggleStatus.test.ts` had 11 copies of:

```ts
editMock.mock.calls[0][0](builder);
```

A bare `!` would have satisfied the compiler, but it keeps the bad failure mode: if `edit` is never called, the test dies as `undefined is not a function` several frames from the cause. They now go through a helper:

```ts
function applyEdit(editMock: Mock, builder: EditBuilder): void {
  const call = editMock.mock.calls[0];
  if (!call) {
    throw new Error("expected editor.edit to have been called");
  }
  (call[0] as (builder: EditBuilder) => void)(builder);
}
```

The file already defines local helpers (`setupEditor`), so this follows its shape rather than introducing a new convention. The guard is reachable — verified against a mock that was never called.

The twelfth, in `BinaryManager.test.ts`, becomes optional chaining, matching two sites already written that way a few hundred lines above it.

## Running the type check locally

The gap this closes: esbuild strips types without checking them, so `vitest` alone can never fail on a type error. Before this PR the only thing that caught one was a CI step — you found out after pushing.

`npm test` now runs `typecheck:test` first, through a `pretest` script. npm invokes that automatically; no new dependency, no git hook, no husky.

| command | type check | use |
|---|---|---|
| `npm test` | yes | before pushing |
| `npm run test:watch` | no | inner loop |
| `npm run test:coverage` | no | coverage runs |
| `npx vitest run <file>` | no | single file |

The fast paths skip it on purpose: `tsc` takes several seconds against a 0.8s test run, and paying that on every watch iteration would just push people back to calling `vitest` directly.

CI keeps its own `typecheck:test` step rather than relying on `pretest`. It repeats work inside the same run, which is the point — that step is the guarantee, so deleting `pretest` later cannot silently drop the check.

Verified both directions with a deliberate type error in a test file: `npm test` refuses to run the suite, `npm run test:coverage` runs all 760 tests without noticing.

## Verification

`npm run compile`, `npm run lint`, `npm run typecheck`, `npm run typecheck:test` and `npm test` all pass. 36 suites, 759 tests, unchanged.
