### PR TITLE
fix(package): stop shipping the tsc debug build in the VSIX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
         npm cache clean --force
         npm ci
     
-    - name: Compile TypeScript
-      run: npm run compile
+    # Not `npm run compile`: that emits a debug build into out/, which then gets
+    # packaged alongside the esbuild bundle. Here we only need the type check.
+    - name: Type-check sources
+      run: npm run typecheck
 
     - name: Run lint
       run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Compile TypeScript
-        run: npm run compile
+      # Not `npm run compile`: that emits a debug build into out/, which then
+      # gets packaged alongside the esbuild bundle. Only the type check is needed.
+      - name: Type-check sources
+        run: npm run typecheck
 
       - name: Run tests
         run: npm test

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,15 +4,21 @@
 .claude/**
 .github/**
 
-# Source code (only compiled JS should be included)
+# Source code (only the esbuild bundle should be included)
 src/**
 *.ts
-*.js.map
-*.map
+*.mts
+*.cts
+**/*.js.map
+**/*.map
+
+# out/ also holds the tsc debug build that `npm run compile` produces for F5.
+# Only the esbuild bundle is loaded at runtime, so ship that and nothing else:
+# package.json "main" points here, and the bundle has no relative requires.
+out/**
+!out/extension/main.js
 
 # Test files and mocks
-out/__mocks__/**
-out/**/__tests__/**
 **/__tests__/**
 **/*.test.js
 **/*.test.ts


### PR DESCRIPTION
Closes #256

Stops the published extension from carrying 392 KB of files that are never loaded.

## Before / after

| | v0.5.42 (published) | this branch |
|---|---|---|
| files in VSIX | 84 | 16 |
| entries under `out/` | 66 | 1 |
| size | 481 KB | 389 KB |

Only `out/extension/main.js` — the esbuild bundle — is ever loaded. Grepping the published bundle for relative requires returns zero matches, so the 32 sibling `.js` modules were unreachable, and VS Code never reads the 33 `.map` files.

## What caused it

Both workflows ran `npm run compile` immediately before packaging. That is `tsc -p tsconfig.dev.json` with `outDir: out`, so it filled the directory `vsce` was about to zip. It stayed invisible because the local path is different: `npm run package` cleans first via its `prepackage` hook, while CI calls `npx vsce package` directly.

## What changed

**`compile` is left alone.** My first read of this — recorded in the issue — was that its output was dead and the script should become `--noEmit`. That was wrong: `.vscode/launch.json` runs it as the `preLaunchTask` for all three debug configurations and resolves breakpoints through `outFiles: out/**/*.js`. That is also why `tsconfig.dev.json` sets `sourceMap: true` where `tsconfig.json` sets it to `false`. Making it `--noEmit` would have broken F5.

**Both workflows call `npm run typecheck` instead.** In CI `compile` was only ever a type check, and `typecheck` is the same check without writing to `out/`. No coverage is lost: `typecheck` covers source, `typecheck:test` covers tests.

**`.vscodeignore` now states the packaged contents positively** — `out/**` excluded with a `!out/extension/main.js` exception. Fixing only the CI order would leave the same trap for anyone running `vsce package` after an F5 session. Verified against a deliberately dirty `out/`: 66 files on disk, one in the package.

Two pattern bugs fixed alongside it:

- `*.js.map` and `*.map` only ever matched the repository root. That is why 33 nested maps shipped despite an explicit rule against them. Now `**/*.map`.
- `*.ts` does not match `.mts`, so **`vitest.config.mts` has been shipping since #253** — a regression I introduced in the migration. Added `*.mts` and `*.cts`.

`out/__mocks__/**` and `out/**/__tests__/**` are dropped as redundant under `out/**`.

## Verification

- Packaged with a deliberately dirty `out/` (66 files present): only `out/extension/main.js` is included.
- Diffed the shipped file list against a clean local build on `main`: **identical**. This removes only what a clean build already excluded — it makes the CI path match the local one.
- `npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm test`, `npm run compile` and `npm run build` all pass. `compile` still emits the debug build for F5.

## Note for the reviewer

Three files in my local package listing (`plan.md`, `plan.html`, `research.md`) are my own untracked scratch files, hidden by a global gitignore rather than by this repo. They are not in the repository and do not affect CI builds — mentioning it so the numbers above reconcile if you reproduce them locally.
