### PR TITLE
chore(build): make tsconfig.dev.json extend the base config

### DIFF
--- a/package.json
+++ b/package.json
@@ -724,7 +724,6 @@
   "scripts": {
     "vscode:prepublish": "npm run esbuild:prod",
     "compile": "tsc -p ./tsconfig.dev.json",
-    "compile:prod": "tsc -p ./",
     "esbuild": "node esbuild.js",
     "esbuild:prod": "node esbuild.js --production",
     "esbuild:watch": "node esbuild.js --watch",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,54 +1,18 @@
 {
+  // The debug build: `npm run compile` emits this into out/ so that F5 in
+  // .vscode/launch.json has per-file JS and source maps to set breakpoints in.
+  // The shipped extension is the esbuild bundle, not this output.
+  //
+  // Everything except the two settings below is inherited, so strictness cannot
+  // drift between this config and tsconfig.json.
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2018",
-    "outDir": "out",
-    "lib": ["es2018"],
-    "sourceMap": true,
-    "rootDir": "src",
-
-    // Enhanced strict type checking
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-
-    // Additional safety checks (disabled for now to fix existing code gradually)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-
-    // Module resolution and compatibility
-    // See tsconfig.json for why vscode-languageclient/node is mapped here.
-    "baseUrl": ".",
-    "paths": {
-      "vscode-languageclient/node": ["node_modules/vscode-languageclient/lib/node/main"]
-    },
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "checkJs": false,
-
-    // Modern TypeScript features
-    "useDefineForClassFields": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "sourceMap": true
   },
   "include": ["src/**/*"],
-  // Tests are type-checked by `npm run typecheck:test` against tsconfig.test.json,
-  // which carries the settings they actually need (ESM for top-level await, and
-  // the relaxed strictness the mocks rely on). This config emits the extension,
-  // so compiling test sources into out/ serves no purpose either.
+  // Same idea as the base config, plus the vscode mock: none of it belongs in a
+  // debug build of the extension. Tests are type-checked by
+  // `npm run typecheck:test` against tsconfig.test.json.
   "exclude": [
     "node_modules",
     ".vscode-test",


### PR DESCRIPTION
Closes #258

## What the configs actually differed by

`tsconfig.dev.json` restated the entire strict block rather than extending `tsconfig.json`. Comparing them option by option:

```
DIFF compilerOptions.sourceMap   base=false  dev=true
```

That is the whole list. Every strictness flag was duplicated verbatim. The risk is not the duplication itself but the drift it invites: tightening a flag in one config leaves the other behind, and nothing reports it.

It now extends the base and overrides two things — `sourceMap`, and the exclude list. The exclude stays written out because `extends` replaces arrays rather than merging them, and the debug build additionally skips `src/__mocks__/**`.

The file also gained a header saying what it is for, since that was not obvious and led me to the wrong conclusion once already: it exists so `npm run compile` can emit per-file JS with source maps for the F5 configurations in `.vscode/launch.json`.

## `compile:prod` removed

```json
"compile:prod": "tsc -p ./",
```

Referenced from nowhere — no workflow, no other script, no documentation. Checked across the repository.

## What is left

| script | purpose |
|---|---|
| `compile` | debug build for F5 (emits) |
| `typecheck` | source type check |
| `typecheck:test` | test type check |
| `build` | esbuild bundle, the thing that ships |

## Verification

`npm run compile` emits **the same 66 files** before and after — I diffed the full file listing against a stash of `main`, identical. `npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm test` and `npm run build` all pass.
