### PR TITLE
docs: correct the stale Jest reasoning left in tsconfig.json

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -27,7 +27,6 @@ testdata/**
 # Build and development configuration
 .gitignore
 tsconfig*.json
-jest.config.js
 eslint.config.js
 eslint.config.mjs
 esbuild.js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,9 +30,13 @@
     // Module resolution and compatibility
     // vscode-languageclient v10 exposes its node entrypoint only via the
     // package.json "exports" map, which the classic "node" resolver ignores.
-    // Map the subpath to the real types so resolution works without switching
-    // the whole project to node16/bundler resolution (which would force ESM
-    // emit or .js import extensions and break the CJS dev build and ts-jest).
+    // Mapping the subpath to the real types works around that.
+    //
+    // The alternative is moduleResolution "bundler", under which this mapping
+    // is unnecessary. It is blocked by "module": "commonjs" (TS5095: bundler
+    // needs es2015 or later), and that has to stay: `npm run compile` emits the
+    // per-file debug build that F5 loads through the extension host, which
+    // requires CommonJS. Drop this mapping if that build ever stops being CJS.
     "baseUrl": ".",
     "paths": {
       "vscode-languageclient/node": ["node_modules/vscode-languageclient/lib/node/main"]


### PR DESCRIPTION
Closes #259

## The comment, checked rather than rewritten

`tsconfig.json` guarded the `vscode-languageclient/node` paths mapping with this:

> …without switching the whole project to node16/bundler resolution (which would force ESM emit or .js import extensions and break the CJS dev build and **ts-jest**).

ts-jest has not been in the project since #253. That is the bad kind of stale comment — not merely out of date, but discouraging someone from revisiting a decision whose constraints have genuinely changed.

So I tested the alternative instead of just deleting the dead half:

| attempt | result |
|---|---|
| `moduleResolution: bundler` + `module: commonjs` (current) | `TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later` |
| `moduleResolution: bundler` + `module: esnext` | compiles clean |
| the same, with `"paths": {}` | **compiles clean** — the mapping becomes unnecessary |

The conclusion is that the mapping is still correct, but for one reason rather than two: `module: commonjs` has to stay because `npm run compile` emits the per-file debug build that F5 loads through the extension host, and that has to be CommonJS. (The shipped bundle is CJS too, but that comes from esbuild's `format: 'cjs'`, not from tsconfig.)

The comment now says that in present tense, and names the condition under which the mapping could be dropped.

## `.vscodeignore`

`jest.config.js` removed — the file no longer exists.

## Noticed, deliberately not touched

- `.vscodeignore` also lists `eslint.config.js`, which does not exist either; only `eslint.config.mjs` does. Same defect class, outside this issue's scope.
- `CHANGELOG.md` has ten historical Jest entries. Those stay: it is generated by CI and records what actually happened.
- The remaining hits in a full-repository sweep were all in untracked files (`.claude/` planning docs, local scratch), so nothing else in the repository refers to Jest.

## Verification

`npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm test`, `npm run compile` and `npm run build` pass. `npx vsce ls` still yields the same 16 files, so the `.vscodeignore` edit changed nothing about what ships.
