### PR TITLE
chore(test): add coverage thresholds and enforce them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,10 @@ jobs:
     - name: Type-check tests
       run: npm run typecheck:test
 
-    - name: Run tests
-      run: npm test
+    # Runs the same suite as `npm test` and additionally enforces the coverage
+    # thresholds. Costs about a second; a threshold nothing executes is no guard.
+    - name: Run tests with coverage
+      run: npm run test:coverage
       if: success()
     
     - name: Package extension

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run build          # Production build with esbuild
 npm run watch          # Watch mode with esbuild
 npm run test           # Type-check the tests, then run them
 npm run test:watch     # Tests in watch mode (no type check)
-npm run test:coverage  # Tests with coverage report (no type check)
+npm run test:coverage  # Tests with coverage report, enforces thresholds (no type check)
 npm run lint           # ESLint check
 npm run lint:fix       # ESLint with auto-fix
 npm run package        # Create VSIX for distribution

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,6 +20,21 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.d.ts', 'src/**/__tests__/**', 'src/__mocks__/**'],
+      // A ratchet, not a target: these sit just under the lowest figure the
+      // suite currently produces, so coverage cannot slide without someone
+      // noticing. Raise them when real coverage rises.
+      //
+      // The headroom is not decorative. Coverage is not deterministic here:
+      // HLedgerCliService swings between 32% and 39% depending on whether its
+      // fire-and-forget constructor init finishes inside the 100 ms sleep the
+      // timeout test waits on, which moves the total by up to 0.9 points. The
+      // observed floor is 81.77 / 76.62 / 81.01 / 82.03.
+      thresholds: {
+        statements: 81,
+        branches: 76,
+        functions: 80,
+        lines: 81,
+      },
     },
   },
 });


### PR DESCRIPTION
Closes #260

Coverage was measurable but unwatched — no thresholds, and no workflow ran it, so the number was only ever seen by whoever typed the command.

## Thresholds

Set as a ratchet just under the current floor, not as a target worth chasing:

| | threshold | current floor |
|---|---|---|
| statements | 81 | 81.77 |
| branches | 76 | 76.62 |
| functions | 80 | 81.01 |
| lines | 81 | 82.03 |

Verified in both directions: the suite passes them on repeated runs, and temporarily raising `statements` to 99 does fail the run with `ERROR: Coverage for statements (82.06%) does not meet global threshold (99%)`. The guard is real, not decorative.

## Why the headroom is not arbitrary

Coverage here is **not deterministic**. Across eight consecutive runs on an unchanged tree the total alternates between two stable values, and the difference isolates to a single file:

```
HLedgerCliService.ts | 32.22 % stmts …
HLedgerCliService.ts | 38.88 % stmts …
```

`HLedgerCliService`'s constructor starts initialisation with `void this.ensureInitialized()`, and `HLedgerCliService.timeout.test.ts` waits for it with `await new Promise(r => setTimeout(r, 100))`. Whether initialisation wins that race decides how much of `resolveHledgerPath` runs. Tests pass either way, which is the uncomfortable part — the assertions sometimes check less than they name.

Filed as #267. The thresholds are set to tolerate the swing, and the config comment says so rather than leaving the next reader to wonder why they look slack.

## CI

`npm test` → `npm run test:coverage`. Same suite, plus the threshold check.

Measured cost: **1s → 2s**. When I filed #260 I wrote that running coverage in CI "roughly triples the test step" and offered it as an argument against — that was true as a ratio and misleading in absolute terms. One second does not need weighing.

Type checking is unaffected: CI has its own `typecheck:test` step, which is what guarantees it rather than the `pretest` hook.

## Verification

`npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm test`, `npm run test:coverage` and `npm run build` all pass.
