### PR TITLE
fix(test): remove the init race that made coverage non-deterministic

### DIFF
--- a/src/extension/__tests__/HLedgerCliCommands.test.ts
+++ b/src/extension/__tests__/HLedgerCliCommands.test.ts
@@ -8,6 +8,28 @@ import { HLedgerCliCommands } from '../HLedgerCliCommands';
 import { HLedgerCliService } from '../services/HLedgerCliService';
 import * as vscode from 'vscode';
 
+// Constructing HLedgerCliService starts path resolution, which shells out to
+// `which hledger` and then `<path> --version`. No assertion here depends on
+// that -- every test stubs the service methods it uses -- but leaving it real
+// made these unit tests spawn processes and behave differently depending on
+// whether hledger happens to be installed. Stub both calls as "not found".
+vi.mock('child_process', () => ({
+    exec: vi.fn((...args: unknown[]) => {
+        const callback = args[args.length - 1];
+        if (typeof callback === 'function') {
+            (callback as (e: Error) => void)(new Error('not found'));
+        }
+        return {};
+    }),
+    execFile: vi.fn((...args: unknown[]) => {
+        const callback = args[args.length - 1];
+        if (typeof callback === 'function') {
+            (callback as (e: Error) => void)(new Error('not found'));
+        }
+        return {};
+    }),
+}));
+
 describe('HLedgerCliCommands - Progress Indicators', () => {
     let tempDir: string;
     let validJournalPath: string;
@@ -16,12 +38,15 @@ describe('HLedgerCliCommands - Progress Indicators', () => {
     let mockEditor: any;
     let mockDocument: any;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hledger-test-'));
         validJournalPath = path.join(tempDir, 'test.journal');
         fs.writeFileSync(validJournalPath, '2025-01-01 Test\n  Assets:Bank  $100\n');
 
         mockService = new HLedgerCliService();
+        // Await the fire-and-forget init the constructor starts, so it cannot
+        // still be resolving when the test ends and skew coverage.
+        await mockService.getHledgerPath();
         commands = new HLedgerCliCommands(mockService);
 
         mockDocument = {
@@ -166,8 +191,11 @@ describe('HLedgerCliCommands - Command Injection Prevention', () => {
         let commands: HLedgerCliCommands;
         let mockService: HLedgerCliService;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             mockService = new HLedgerCliService();
+            // Await the fire-and-forget init the constructor starts, so it cannot
+            // still be resolving when the test ends and skew coverage.
+            await mockService.getHledgerPath();
             commands = new HLedgerCliCommands(mockService);
         });
 
@@ -331,8 +359,11 @@ describe('HLedgerCliCommands - Command Injection Prevention', () => {
         let mockService: HLedgerCliService;
         let mockDocument: any;
 
-        beforeEach(() => {
+        beforeEach(async () => {
             mockService = new HLedgerCliService();
+            // Await the fire-and-forget init the constructor starts, so it cannot
+            // still be resolving when the test ends and skew coverage.
+            await mockService.getHledgerPath();
             commands = new HLedgerCliCommands(mockService);
             mockDocument = {
                 uri: { fsPath: validJournalPath },

--- a/src/extension/services/__tests__/HLedgerCliService.timeout.test.ts
+++ b/src/extension/services/__tests__/HLedgerCliService.timeout.test.ts
@@ -11,6 +11,23 @@ vi.mock('child_process', () => ({
 }));
 
 const mockExec = child_process.exec as MockedFunction<typeof child_process.exec>;
+const mockExecFile = child_process.execFile as MockedFunction<typeof child_process.execFile>;
+
+/**
+ * Path resolution runs `which hledger` and then validates the candidate with
+ * `<path> --version`. Both go through promisify, so a mock that never invokes
+ * its callback leaves the promise pending forever and initialization never
+ * finishes. Give execFile a callback so awaiting the service actually resolves.
+ */
+function stubExecFileSuccess(): void {
+    mockExecFile.mockImplementation(((...args: unknown[]) => {
+        const callback = args[args.length - 1];
+        if (typeof callback === 'function') {
+            (callback as (e: null, stdout: string, stderr: string) => void)(null, 'hledger 1.52.1\n', '');
+        }
+        return {} as never;
+    }) as never);
+}
 
 describe('HLedgerCliService - Timeout Protection', () => {
     beforeEach(() => {
@@ -28,10 +45,14 @@ describe('HLedgerCliService - Timeout Protection', () => {
                 return {} as any;
             }) as any);
 
+            stubExecFileSuccess();
+
             const service = new HLedgerCliService();
 
-            // Wait for initialization to complete
-            await new Promise(resolve => setTimeout(resolve, 100));
+            // Await the initialization the constructor kicked off. getHledgerPath
+            // goes through the same ensureInitialized promise, so this is exact
+            // where a fixed sleep was a race.
+            await service.getHledgerPath();
 
             // Verify exec was called with timeout option
             expect(mockExec).toHaveBeenCalled();
@@ -68,10 +89,11 @@ describe('HLedgerCliService - Timeout Protection', () => {
                 return {} as any;
             }) as any);
 
+            stubExecFileSuccess();
+
             const service = new HLedgerCliService();
 
-            // Wait for initialization
-            await new Promise(resolve => setTimeout(resolve, 100));
+            await service.getHledgerPath();
 
             // Verify timeout is exactly 5000ms
             expect(timeoutValues).toContain(5000);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,20 +20,20 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.d.ts', 'src/**/__tests__/**', 'src/__mocks__/**'],
-      // A ratchet, not a target: these sit just under the lowest figure the
-      // suite currently produces, so coverage cannot slide without someone
-      // noticing. Raise them when real coverage rises.
+      // A ratchet, not a target: these sit just under what the suite currently
+      // produces, so coverage cannot slide without someone noticing. Raise them
+      // when real coverage rises.
       //
-      // The headroom is not decorative. Coverage is not deterministic here:
-      // HLedgerCliService swings between 32% and 39% depending on whether its
-      // fire-and-forget constructor init finishes inside the 100 ms sleep the
-      // timeout test waits on, which moves the total by up to 0.9 points. The
-      // observed floor is 81.77 / 76.62 / 81.01 / 82.03.
+      // The margin is small on purpose. Coverage used to swing between runs and
+      // between machines, so the first version of these numbers had to absorb
+      // almost a point of noise. It no longer does: the suite reports
+      // 81.91 / 76.70 / 81.30 / 82.18 on every run, with or without hledger
+      // installed. A drop now means coverage actually fell.
       thresholds: {
-        statements: 81,
-        branches: 76,
-        functions: 80,
-        lines: 81,
+        statements: 81.5,
+        branches: 76.5,
+        functions: 81,
+        lines: 82,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -24,14 +24,18 @@ export default defineConfig({
       // produces, so coverage cannot slide without someone noticing. Raise them
       // when real coverage rises.
       //
-      // The margin is small on purpose. Coverage used to swing between runs and
-      // between machines, so the first version of these numbers had to absorb
-      // almost a point of noise. It no longer does: the suite reports
-      // 81.91 / 76.70 / 81.30 / 82.18 on every run, with or without hledger
-      // installed. A drop now means coverage actually fell.
+      // Statements, functions and lines are now reproducible to the digit --
+      // 81.91 / 81.30 / 82.18 on every run, with or without hledger installed
+      // and on both macOS and the Linux runner -- so their margin is thin on
+      // purpose. A drop there means coverage actually fell.
+      //
+      // Branches still move with the platform: HLedgerImportCommands reports
+      // 44% locally and 42.66% on CI, because a filesystem error path is taken
+      // differently, which shifts the total between 76.62 and 76.70. That one
+      // keeps a wider margin until the branch itself is pinned down.
       thresholds: {
         statements: 81.5,
-        branches: 76.5,
+        branches: 76,
         functions: 81,
         lines: 82,
       },


### PR DESCRIPTION
Closes #267

## Result

Coverage is now reproducible to the digit for statements, functions and lines:

```
81.91 / … / 81.30 / 82.18
```

Verified six runs with `hledger` on PATH, six with it removed, and confirmed against the CI runner. Before this it alternated between 81.77 and 82.06 locally and produced a third value without hledger.

Branches are the exception and I want to be precise about it: CI reports 76.62% where macOS reports 76.70%. That difference is not this race — it isolates to `HLedgerImportCommands`, 44% locally against 42.66% on Linux, with every other metric identical, because a filesystem error path is taken differently between the platforms. The branch threshold keeps a wider margin because of it. Happy to file that separately.

## The issue named half the cause

#267 described `HLedgerCliService.timeout.test.ts` sleeping 100 ms instead of awaiting initialisation. That was real. Tracing the swing to its source turned up a second and larger one:

`HLedgerCliCommands.test.ts` constructs a **real** `HLedgerCliService` in three `beforeEach` blocks and does not mock `child_process`. Every construction spawned `which hledger` and then `hledger --version`. Whether those finished before the run ended decided how much of `resolveHledgerPath` was counted — and on a machine with hledger installed the answer differed from one without, which is why the numbers also moved between local and CI.

Unit tests were shelling out.

## No production change was needed

`getHledgerPath()` already awaits the same `ensureInitialized` promise the constructor starts. Tests can await that directly rather than guess a duration. The constructor stays non-blocking.

**`HLedgerCliService.timeout.test.ts`** — awaits `getHledgerPath()` instead of sleeping.

Its `execFile` mock also had to start invoking its callback, and that exposed something: `promisify` over a `vi.fn()` that ignores its callback returns a promise that never settles. Initialisation in that file had therefore **never been completing at all** — `resolveHledgerPath` hung at the validation step every time, and the sleep hid it. The assertions passed because they only inspect `mockExec.mock.calls`.

**`HLedgerCliCommands.test.ts`** — mocks `child_process`, both calls stubbed as "not found".

Nothing there depended on a real one: every test stubs the service methods it uses (`vi.spyOn(mockService, 'isHledgerAvailable')` and friends), and the service exists only to satisfy `new HLedgerCliCommands(service)`. The `await getHledgerPath()` calls stay, so initialisation is finished before any assertion regardless.

## Thresholds tightened

With the noise gone they no longer need to absorb it:

| | before | now | measured floor |
|---|---|---|---|
| statements | 81 | 81.5 | 81.91 |
| branches | 76 | 76 (unchanged) | 76.62 on CI, 76.70 on macOS |
| functions | 80 | 81 | 81.30 |
| lines | 81 | 82 | 82.18 |

## Side effect worth having

`HLedgerCliCommands.test.ts` no longer spawns processes: **1.04s → 0.22s**. Full suite drops to 630 ms.

## Verification

`npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm test`, `npm run test:coverage` and `npm run build` pass. `test:coverage` also passes under a PATH with hledger removed, which is the case CI actually runs.
