### PR TITLE
fix(test): skip the permission-based path test when running as root

### DIFF
--- a/src/extension/__tests__/HLedgerCliCommands.test.ts
+++ b/src/extension/__tests__/HLedgerCliCommands.test.ts
@@ -8,6 +8,9 @@ import { HLedgerCliCommands } from '../HLedgerCliCommands';
 import { HLedgerCliService } from '../services/HLedgerCliService';
 import * as vscode from 'vscode';
 
+/** getuid is absent on Windows, where the optional call yields undefined. */
+const isRoot = process.getuid?.() === 0;
+
 // Constructing HLedgerCliService starts path resolution, which shells out to
 // `which hledger` and then `<path> --version`. No assertion here depends on
 // that -- every test stubs the service methods it uses -- but leaving it real
@@ -318,7 +321,12 @@ describe('HLedgerCliCommands - Command Injection Prevention', () => {
             }).toThrow(/does not exist or is not accessible/);
         });
 
-        it('should reject unreadable paths', () => {
+        // Root bypasses file permission checks, so chmod 000 does not make a
+        // file unreadable and there is nothing for sanitizeJournalPath to
+        // reject. CI runs as a normal user, but container images default to
+        // root -- without this the suite fails there and looks like a real
+        // regression in path validation.
+        it.skipIf(isRoot)('should reject unreadable paths', () => {
             const unreadablePath = path.join(tempDir, 'unreadable.journal');
             fs.writeFileSync(unreadablePath, 'test');
             fs.chmodSync(unreadablePath, 0o000);


### PR DESCRIPTION
Closes #272

Takes option A from the issue: skip the assertion where it cannot mean anything, rather than weakening it everywhere.

```ts
/** getuid is absent on Windows, where the optional call yields undefined. */
const isRoot = process.getuid?.() === 0;

it.skipIf(isRoot)('should reject unreadable paths', () => { … });
```

The test chmods a file to `000` and expects `sanitizeJournalPath` to reject it. Root bypasses file permission checks, so the read succeeds and nothing is thrown.

Option B — mocking the access check — would make the test pass everywhere, but it would stop exercising the real `fs` call, which is the only part of that assertion worth having. Skipping keeps it honest where permissions apply and says so in place.

## Verified three ways

| environment | uid | result |
|---|---|---|
| macOS, normal user | 501 | test **runs**, 772 passed |
| `node:22-slim`, `--user 1000:1000` | 1000 | test **runs**, 772 passed |
| `node:22-slim`, default | 0 | test **skipped**, 771 passed + 1 skipped |

The last one previously failed with `AssertionError: expected [Function] to throw an error`.

CI is unaffected and always has been — `ubuntu-latest` runs jobs as the non-root `runner` user, which is exactly why this went unnoticed until the suite was run in a container.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:test`, `npm test`, `npm run test:coverage` and `npm run build` all pass. Coverage unchanged.
