### PR TITLE
chore(deps-dev): bump @typescript-eslint/parser from 8.66.0 to 8.67.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "26.x",
         "@types/vscode": "^1.110.0",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "@vitest/coverage-v8": "^4.1.10",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.2",

--- a/package.json
+++ b/package.json
@@ -749,7 +749,7 @@
     "@types/node": "26.x",
     "@types/vscode": "^1.110.0",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
-    "@typescript-eslint/parser": "^8.65.0",
+    "@typescript-eslint/parser": "^8.67.0",
     "@vitest/coverage-v8": "^4.1.10",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.2",


### PR DESCRIPTION
Replaces #280.

Dependabot's branch for the `@typescript-eslint/parser` 8.67.0 bump conflicts
with `main` on `package-lock.json` after #279 (eslint-plugin 8.67.0) landed.
A `@dependabot rebase` request got no response for 12+ minutes, so this PR
carries the same change rebased onto current `main`.

Note: parser 8.67.0 is already present in the lockfile transitively via
eslint-plugin 8.67.0, so the lockfile diff is a single spec line.
