### PR TITLE
chore(deps): stop dependabot from bumping @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
         versions: [">=3.0.0"]
       - dependency-name: "typescript"
         versions: [">=6.0.0"]
+      # Must match engines.vscode in package.json: vsce refuses to package when
+      # the types are newer. Bump it manually together with engines.vscode.
+      - dependency-name: "@types/vscode"


### PR DESCRIPTION
`@types/vscode` must not go past `engines.vscode` — `vsce package` fails outright when it does, which is why #282 could never turn green. Ignoring the dependency so the PR is not recreated weekly; bump it by hand whenever `engines.vscode` moves.

Closes the loop on #282.