### PR TITLE
fix(lsp): recover from stale binary version metadata

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -322,6 +322,12 @@ The Language Server is auto-installed on first activation. If it is not installe
 
 4. **Corporate proxy:** Set VS Code's `http.proxy` to use that proxy for both HTTP and HTTPS Language Server downloads. If `http.proxy` is empty, downloads use `HTTP_PROXY` and `HTTPS_PROXY`; `NO_PROXY` still bypasses the proxy for matching hosts. Reload VS Code after changing proxy settings. Manual installation remains available if the network policy requires a proxy method the extension does not support.
 
+### Server Stays Old After an Update
+
+An earlier failed update could replace `version.txt` while leaving the old executable in place. This caused "Already up to date" to appear even when the server lacked newer features, such as inferred amount hints.
+
+Update the extension, then run **HLedger: Install/Update Language Server** again. Update checks now read the auto-downloaded executable's `--version` output, and the installer records the new version only after replacing the binary. A custom executable configured through `hledger.lsp.path` must still be updated separately.
+
 ### GitHub Rate Limit Errors
 
 **Symptoms:** "GitHub API rate limit exceeded" when installing/updating

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -886,6 +886,8 @@ To manually reinstall or update:
 2. Run **HLedger: Install/Update Language Server**
 3. Wait for the download to complete
 
+Update checks read the version reported by the auto-downloaded executable. If an earlier update left an old binary with newer version metadata, running **HLedger: Install/Update Language Server** detects the old version and offers the update again.
+
 ### Status Bar
 
 The extension shows an LSP status indicator in the VS Code status bar (bottom-right). The indicator reflects the current state of the Language Server:

--- a/src/extension/lsp/BinaryManager.ts
+++ b/src/extension/lsp/BinaryManager.ts
@@ -1,3 +1,4 @@
+import { execFile } from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as os from "os";
@@ -15,6 +16,8 @@ const GITHUB_REPO = "juev/hledger-lsp";
 const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
 const MAX_BINARY_SIZE = 50 * 1024 * 1024;
 const MIN_BINARY_SIZE = 1024;
+const VERSION_TIMEOUT_MS = 5_000;
+const MAX_VERSION_OUTPUT_SIZE = 64 * 1024;
 
 const API_TIMEOUT_MS = 30_000;
 const DOWNLOAD_TIMEOUT_MS = 300_000;
@@ -364,12 +367,31 @@ export class BinaryManager {
   }
 
   async getInstalledVersion(): Promise<string | null> {
-    try {
-      const version = await fs.promises.readFile(this.getVersionPath(), "utf-8");
-      return version.trim();
-    } catch {
-      return null;
-    }
+    // A previous failed installation may have updated version.txt while leaving
+    // the old executable in place. Only the executable can identify its version.
+    return new Promise((resolve) => {
+      execFile(
+        this.getBinaryPath(),
+        ["--version"],
+        {
+          encoding: "utf8",
+          timeout: VERSION_TIMEOUT_MS,
+          maxBuffer: MAX_VERSION_OUTPUT_SIZE,
+          windowsHide: true,
+          shell: false,
+        },
+        (error, stdout) => {
+          if (error) {
+            resolve(null);
+            return;
+          }
+          const version = stdout.trim().match(
+            /^hledger-lsp v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?:\s|$)/,
+          )?.[1];
+          resolve(version ? `v${version}` : null);
+        },
+      );
+    });
   }
 
   async getLatestRelease(): Promise<ReleaseInfo> {
@@ -589,9 +611,10 @@ export class BinaryManager {
       // the executable before the atomic replacement.
       await beforeInstall?.();
 
-      // Atomic rename: version file first, then binary (safer to have missing version than missing binary)
-      await fs.promises.rename(tempVersionPath, versionPath);
+      // Record the release only after its executable has replaced the old one.
+      // A locked Windows executable must not leave behind newer version metadata.
       await fs.promises.rename(tempBinaryPath, binaryPath);
+      await fs.promises.rename(tempVersionPath, versionPath);
     } catch (error) {
       // Cleanup temp files on error
       try {

--- a/src/extension/lsp/__tests__/BinaryManager.test.ts
+++ b/src/extension/lsp/__tests__/BinaryManager.test.ts
@@ -12,6 +12,20 @@ import {
 import { verify as verifyMinisign } from "../minisignVerify";
 import * as vscode from "vscode";
 
+const mockExecFile = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ execFile: mockExecFile }));
+
+function mockBinaryVersion(stdout: string, error: Error | null = null) {
+  mockExecFile.mockImplementation((
+    _file: string,
+    _args: string[],
+    _options: unknown,
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    callback(error, stdout, "");
+  });
+}
+
 vi.mock("undici", () => ({
   fetch: vi.fn(),
   EnvHttpProxyAgent: vi.fn(),
@@ -187,6 +201,7 @@ describe("BinaryManager", () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hledger-lsp-test-"));
     manager = new BinaryManager(tempDir);
     (verifyMinisign as Mock).mockReturnValue(true);
+    mockBinaryVersion("", new Error("ENOENT"));
   });
 
   afterEach(() => {
@@ -221,19 +236,57 @@ describe("BinaryManager", () => {
   });
 
   describe("getInstalledVersion", () => {
-    it("returns null when version file does not exist", async () => {
+    it("returns null when the binary cannot be executed", async () => {
+      fs.writeFileSync(path.join(tempDir, "version.txt"), "v0.2.56");
       const version = await manager.getInstalledVersion();
 
       expect(version).toBeNull();
     });
 
-    it("returns version from version file", async () => {
-      const versionPath = path.join(tempDir, "version.txt");
-      fs.writeFileSync(versionPath, "v0.1.0");
+    it("returns the binary version even when metadata claims a newer release", async () => {
+      fs.writeFileSync(path.join(tempDir, "version.txt"), "v0.2.56");
+      mockBinaryVersion("hledger-lsp 0.2.49 (commit: 9851d3a, built: 2026-06-18T07:03:39Z)\r\n");
 
       const version = await manager.getInstalledVersion();
 
-      expect(version).toBe("v0.1.0");
+      expect(version).toBe("v0.2.49");
+    });
+
+    it.each(["0.2.56", "v0.2.56", "0.2.57-rc.1+build.2"])(
+      "reads release %s without a version file",
+      async (version) => {
+        mockBinaryVersion(`hledger-lsp ${version} (commit: test, built: unknown)\n`);
+
+        expect(await manager.getInstalledVersion()).toBe(`v${version.replace(/^v/, "")}`);
+      },
+    );
+
+    it.each(["", "hledger-lsp dev (commit: none, built: unknown)", "v0.2.56", "hledger-lsp 0.2.56broken"])(
+      "returns null for unrecognized version output %j",
+      async (stdout) => {
+        mockBinaryVersion(stdout);
+
+        expect(await manager.getInstalledVersion()).toBeNull();
+      },
+    );
+
+    it("does not trust version output from a failed process", async () => {
+      mockBinaryVersion("hledger-lsp 0.2.56", new Error("process timed out"));
+
+      expect(await manager.getInstalledVersion()).toBeNull();
+    });
+
+    it("probes the managed Windows executable directly with bounded execution", async () => {
+      manager = new BinaryManager(path.join(tempDir, "storage space & 中文"), undefined, getPlatformInfo("win32", "x64"));
+      mockBinaryVersion("hledger-lsp 0.2.56");
+
+      expect(await manager.getInstalledVersion()).toBe("v0.2.56");
+      expect(mockExecFile).toHaveBeenCalledWith(
+        manager.getBinaryPath(),
+        ["--version"],
+        expect.objectContaining({ timeout: 5000, maxBuffer: 64 * 1024, windowsHide: true, shell: false }),
+        expect.any(Function),
+      );
     });
   });
 
@@ -541,7 +594,8 @@ describe("BinaryManager", () => {
 
     it("returns true when installed version is older", async () => {
       const versionPath = path.join(tempDir, "version.txt");
-      fs.writeFileSync(versionPath, "v0.1.0");
+      fs.writeFileSync(versionPath, "v0.2.0");
+      mockBinaryVersion("hledger-lsp 0.1.0");
 
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -560,7 +614,8 @@ describe("BinaryManager", () => {
 
     it("returns false when installed version is current", async () => {
       const versionPath = path.join(tempDir, "version.txt");
-      fs.writeFileSync(versionPath, "v0.2.0");
+      fs.writeFileSync(versionPath, "v0.1.0");
+      mockBinaryVersion("hledger-lsp 0.2.0");
 
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
@@ -579,6 +634,53 @@ describe("BinaryManager", () => {
   });
 
   describe("download", () => {
+    it("preserves the installed version after a failed binary replacement and allows retry", async () => {
+      const platform = getPlatformInfo("win32", "x64");
+      const binaryContent = Buffer.alloc(2048, "x");
+      const mockFetch = vi.fn(async (url: string) => {
+        if (url.includes("api.github.com")) {
+          return Response.json(await makeGitHubReleaseMock(platform.assetSuffix).json());
+        }
+        if (url.endsWith("checksums.txt")) {
+          return new Response(`${computeSha256(binaryContent)}  hledger-lsp_${platform.assetSuffix}\n`);
+        }
+        if (url.endsWith(".minisig")) {
+          return new Response("test signature");
+        }
+        return new Response(binaryContent.toString("utf8"));
+      });
+      manager = new BinaryManager(tempDir, mockFetch, platform);
+      const binaryPath = manager.getBinaryPath();
+      const versionPath = path.join(tempDir, "version.txt");
+      fs.writeFileSync(binaryPath, "old server");
+      fs.writeFileSync(versionPath, "v0.0.1");
+      mockBinaryVersion("hledger-lsp 0.0.1");
+
+      const rename = fs.promises.rename;
+      const lockedBinary = Object.assign(new Error("executable is locked"), { code: "EPERM" });
+      const renameSpy = vi.spyOn(fs.promises, "rename").mockImplementation(async (source, destination) => {
+        if (destination === binaryPath) {
+          throw lockedBinary;
+        }
+        await rename(source, destination);
+      });
+
+      await expect(manager.download()).rejects.toThrow(lockedBinary);
+
+      expect(fs.readFileSync(binaryPath, "utf8")).toBe("old server");
+      expect(fs.readFileSync(versionPath, "utf8")).toBe("v0.0.1");
+      expect(fs.readdirSync(tempDir).sort()).toEqual(["hledger-lsp.exe", "version.txt"]);
+      expect(await manager.needsUpdate()).toBe(true);
+
+      renameSpy.mockRestore();
+      await manager.download();
+      mockBinaryVersion("hledger-lsp 0.1.0");
+
+      expect(fs.readFileSync(binaryPath)).toEqual(binaryContent);
+      expect(fs.readFileSync(versionPath, "utf8")).toBe("v0.1.0");
+      expect(await manager.needsUpdate()).toBe(false);
+    });
+
     it("downloads binary and saves version", async () => {
       const binaryContent = Buffer.alloc(2048, "x");
       const assetSuffix = getPlatformInfo(os.platform(), os.arch()).assetSuffix;
@@ -638,7 +740,8 @@ describe("BinaryManager", () => {
       await manager.download();
 
       expect(await manager.isInstalled()).toBe(true);
-      expect(await manager.getInstalledVersion()).toBe("v0.1.0");
+      expect(fs.readFileSync(manager.getBinaryPath())).toEqual(binaryContent);
+      expect(fs.readFileSync(path.join(tempDir, "version.txt"), "utf8")).toBe("v0.1.0");
     });
 
     it("throws when no matching asset found", async () => {
@@ -1262,7 +1365,8 @@ describe("BinaryManager", () => {
       await manager.download();
 
       expect(await manager.isInstalled()).toBe(true);
-      expect(await manager.getInstalledVersion()).toBe("v0.1.0");
+      expect(fs.readFileSync(manager.getBinaryPath())).toEqual(binaryContent);
+      expect(fs.readFileSync(path.join(tempDir, "version.txt"), "utf8")).toBe("v0.1.0");
     });
 
     it("detects stall and retries download", async () => {

--- a/src/extension/lsp/__tests__/LSPManager.test.ts
+++ b/src/extension/lsp/__tests__/LSPManager.test.ts
@@ -104,14 +104,30 @@ describe("LSPManager", () => {
       expect(version).toBeNull();
     });
 
-    it("returns version from version file", async () => {
+    it("returns null when only version metadata remains", async () => {
       fs.writeFileSync(path.join(tempDir, "version.txt"), "v0.1.0");
 
       const manager = new LSPManager(mockContext);
 
       const version = await manager.getVersion();
 
-      expect(version).toBe("v0.1.0");
+      expect(version).toBeNull();
+    });
+  });
+
+  describe("checkForUpdates", () => {
+    it("offers an update when the binary is older than its recorded version", async () => {
+      fs.writeFileSync(path.join(tempDir, "version.txt"), "v0.2.56");
+      vi.spyOn(BinaryManager.prototype, "getInstalledVersion").mockResolvedValue("v0.2.49");
+      vi.spyOn(BinaryManager.prototype, "getLatestRelease").mockResolvedValue({ version: "v0.2.56", assets: [] });
+      const manager = new LSPManager(mockContext);
+
+      expect(await manager.getVersion()).toBe("v0.2.49");
+      expect(await manager.checkForUpdates()).toEqual({
+        hasUpdate: true,
+        currentVersion: "v0.2.49",
+        latestVersion: "v0.2.56",
+      });
     });
   });
 


### PR DESCRIPTION
An interrupted language server update could record the new release while leaving the old executable in place. Subsequent update checks then reported "Already up to date", leaving features such as inferred amount hints unavailable.

Update checks now read the managed executable's version with a timeout and output limit. Installation replaces the binary before recording the release, so a failed replacement preserves the previous metadata. Regression tests cover stale metadata, replacement failure and successful retry; the user guide and troubleshooting guide explain recovery.

Fixes #292

Validation: `npm run typecheck`, `npm run typecheck:test`, `npm run lint`, `npm run test:coverage` (783 tests; coverage thresholds passed), and `npm run esbuild:prod` passed. VSIX packaging also succeeded. A runtime check on macOS read v0.2.56 from the official executable despite deliberately incorrect metadata, using a path with spaces, an ampersand and CJK characters. The Windows replacement failure is simulated with EPERM; a native Windows run remains unverified.
